### PR TITLE
IR calibration

### DIFF
--- a/Data/User/GameConfig/RBUE08.ini
+++ b/Data/User/GameConfig/RBUE08.ini
@@ -13,3 +13,7 @@ PH_ExtraParam = 0
 PH_ZNear = 
 PH_ZFar = 
 [Gecko]
+[WiimoteFirstUse]
+IR/Center = 50
+IR/Width = 40
+IR/Height = 31

--- a/Data/User/GameConfig/RBUP08.ini
+++ b/Data/User/GameConfig/RBUP08.ini
@@ -12,3 +12,7 @@ PH_SZFar = 0
 PH_ExtraParam = 0
 PH_ZNear = 
 PH_ZFar = 0.1
+[WiimoteFirstUse]
+IR/Center = 50
+IR/Width = 40
+IR/Height = 31

--- a/Data/User/GameConfig/RM3E01.ini
+++ b/Data/User/GameConfig/RM3E01.ini
@@ -24,3 +24,7 @@ EFBCopyEnable = True
 DisableWiimoteSpeaker = 1
 [Video_Hacks]
 EFBEmulateFormatChanges = True
+[WiimoteFirstUse]
+IR/Center = 89
+IR/Width = 61
+IR/Height = 72

--- a/Data/User/GameConfig/RM3P01.ini
+++ b/Data/User/GameConfig/RM3P01.ini
@@ -26,3 +26,7 @@ EFBCopyEnable = True
 DisableWiimoteSpeaker = 1
 [Video_Hacks]
 EFBEmulateFormatChanges = True
+[WiimoteFirstUse]
+IR/Center = 89
+IR/Width = 61
+IR/Height = 72

--- a/Data/User/GameConfig/RM8E01.ini
+++ b/Data/User/GameConfig/RM8E01.ini
@@ -22,3 +22,7 @@ PH_ZFar =
 ForceFiltering = False
 [Video_Hacks]
 DlistCachingEnable = False
+[WiimoteFirstUse]
+IR/Center = 52
+IR/Width = 63
+IR/Height = 52

--- a/Data/User/GameConfig/RM8P01.ini
+++ b/Data/User/GameConfig/RM8P01.ini
@@ -17,3 +17,7 @@ PH_ZFar =
 ForceFiltering = False
 [Video_Hacks]
 DlistCachingEnable = False
+[WiimoteFirstUse]
+IR/Center = 52
+IR/Width = 63
+IR/Height = 52

--- a/Data/User/GameConfig/RSPE01.ini
+++ b/Data/User/GameConfig/RSPE01.ini
@@ -12,4 +12,7 @@ EmulationIssues =
 [Video]
 ProjectionHack = 0
 [Gecko]
-
+[WiimoteFirstUse]
+IR/Center = 60
+IR/Width = 54
+IR/Height = 55

--- a/Data/User/GameConfig/RSPP01.ini
+++ b/Data/User/GameConfig/RSPP01.ini
@@ -12,3 +12,7 @@ EmulationIssues =
 [Video]
 ProjectionHack = 0
 [Gecko]
+[WiimoteFirstUse]
+IR/Center = 60
+IR/Width = 54
+IR/Height = 55


### PR DESCRIPTION
## IR calibration
### Problem

When mouse input Cursor (rather than Axis) is used the game cursor isn't at the same location as the system cursor
### Solution
- read IR calibration from ISO ini
- select "Graphics → General → Hide Mouse Cursor"
