### PR TITLE
Adding option to log without file or type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language:
+# linux
+- cpp
+
+# osx
+# - objective-c
+
+env:
+# linux
+- build=release
+- build=debug
+- build=cli
+
+install:
+# linux
+- if [[ "$build" != "cli" ]]; then sudo add-apt-repository -y ppa:fransschreuder1/usbpicprog-stable; fi
+- sudo apt-get -qq update
+- sudo apt-get -qq install git cmake gettext libwayland-dev libsdl1.2-dev libxrandr-dev libxext-dev libglew-dev libavcodec-dev libavformat-dev libsoil-dev libsfml-dev libopenal-dev libao-dev libasound2-dev libpulse-dev libportaudio-dev libsoundtouch-dev libbluetooth-dev libreadline-dev libswscale-dev liblzo2-dev
+- if [[ "$build" != "cli" ]]; then sudo apt-get -qq install wx2.9-headers libwxbase2.9-dev libwxgtk2.9-dev libgtk-3-dev; fi
+- export MAKEFLAGS="-j $((`nproc` / 2))"
+
+# osx
+# - brew update
+# - brew install cmake
+# - export MAKEFLAGS="-j 4"
+
+script:
+- if [[ "$build" == "release" ]]; then cmake . && make; fi
+- if [[ "$build" == "debug" ]]; then cmake -DCMAKE_BUILD_TYPE=Debug . && make; fi
+- if [[ "$build" == "cli" ]]; then cmake -DDISABLE_WX=ON . && make; fi

--- a/Source/Core/Common/Src/ConsoleListener.cpp
+++ b/Source/Core/Common/Src/ConsoleListener.cpp
@@ -235,7 +235,7 @@ void ConsoleListener::PixelSpace(int Left, int Top, int Width, int Height, bool 
 	COORD Coo = GetCoordinates(OldCursor, LBufWidth);
 	SetConsoleCursorPosition(hConsole, Coo);
 
-	if (SLog.length() > 0) Log(LogTypes::LNOTICE, SLog.c_str());
+	if (SLog.length() > 0) Log(LogTypes::NOTICE, SLog.c_str());
 
 	// Resize the window too
 	if (Resize) MoveWindow(GetConsoleWindow(), Left,Top, (Width + 100),Height, true);
@@ -259,19 +259,19 @@ void ConsoleListener::Log(LogTypes::LOG_LEVELS Level, const char *Text)
 
 	switch (Level)
 	{
-	case NOTICE_LEVEL: // light green
+	case LogTypes::NOTICE: // light green
 		Color = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
 		break;
-	case ERROR_LEVEL: // light red
+	case LogTypes::ERROR_: // light red
 		Color = FOREGROUND_RED | FOREGROUND_INTENSITY;
 		break;
-	case WARNING_LEVEL: // light yellow
+	case LogTypes::WARNING: // light yellow
 		Color = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
 		break;
-	case INFO_LEVEL: // cyan
+	case LogTypes::INFO: // cyan
 		Color = FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
 		break;
-	case DEBUG_LEVEL: // gray
+	case LogTypes::DEBUG: // gray
 		Color = FOREGROUND_INTENSITY;
 		break;
 	default: // off-white
@@ -296,20 +296,39 @@ void ConsoleListener::Log(LogTypes::LOG_LEVELS Level, const char *Text)
 		strcpy(ResetAttr, "\033[0m");
 		switch (Level)
 		{
-		case NOTICE_LEVEL: // light green
-			strcpy(ColorAttr, "\033[92m");
-			break;
-		case ERROR_LEVEL: // light red
-			strcpy(ColorAttr, "\033[91m");
-			break;
-		case WARNING_LEVEL: // light yellow
-			strcpy(ColorAttr, "\033[93m");
-			break;
-		default:
+			case LogTypes::NOTICE: // light green
+				strcpy(ColorAttr, "\033[92m");
+				break;
+			case LogTypes::ERROR_: // light red
+				strcpy(ColorAttr, "\033[91m");
+				break;
+			case LogTypes::WARNING: // light yellow
+				strcpy(ColorAttr, "\033[93m");
+				break;
+
+			case LogTypes::BLUE:
+				strcpy(ColorAttr, "\033[94m");
+				break;
+			case LogTypes::CYAN:
+				strcpy(ColorAttr, "\033[96m");
+				break;
+			case LogTypes::MAGENTA:
+				strcpy(ColorAttr, "\033[95m");
+				break;
+			case LogTypes::GREY:
+				strcpy(ColorAttr, "\033[93m");
+				break;
+
+			case LogTypes::WHITE:
+			default:
+				strcpy(ColorAttr, "\033[97m");
+				break;
+
 			break;
 		}
 	}
 	fprintf(stderr, "%s%s%s", ColorAttr, Text, ResetAttr);
+	fflush(stderr);
 #endif
 }
 // Clear console screen

--- a/Source/Core/Common/Src/Log.h
+++ b/Source/Core/Common/Src/Log.h
@@ -77,9 +77,9 @@ enum LOG_LEVELS {
 }  // namespace
 
 void GenericLog(LOGTYPES_LEVELS level, LOGTYPES_TYPE type,
-		const char *file, int line, const char *fmt, ...)
+		bool logFile, bool logType, const char *file, int line, const char *fmt, ...)
 #ifdef __GNUC__
-		__attribute__((format(printf, 5, 6)))
+		__attribute__((format(printf, 7, 8)))
 #endif
 		;
 
@@ -92,20 +92,33 @@ void GenericLog(LOGTYPES_LEVELS level, LOGTYPES_TYPE type,
 #endif // logging
 
 #ifdef GEKKO
-#define GENERIC_LOG(t, v, ...)
+#define GENERIC_LOG_(t, v, true, ...)
 #else
-// Let the compiler optimize this out
-#define GENERIC_LOG(t, v, ...) { \
+// let the compiler optimization remove log levels
+#define GENERIC_LOG_(t, v, bf, bT, ...) { \
 	if (v <= MAX_LOGLEVEL) \
-		GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__); \
+		GenericLog(v, t, bf, bT, __FILE__, __LINE__, __VA_ARGS__); \
 	}
 #endif
+#define GENERIC_LOG(t, v, ...) GENERIC_LOG_(t, v, true, true, __VA_ARGS__)
 
-#define ERROR_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__) } while (0)
-#define WARN_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__) } while (0)
-#define NOTICE_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__) } while (0)
-#define INFO_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__) } while (0)
-#define DEBUG_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) } while (0)
+#define LOG1(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LNOTICE, false, false, __VA_ARGS__) } while (0)
+#define LOG2(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LERROR, false, false, __VA_ARGS__) } while (0)
+#define LOG3(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LWARNING, false, false, __VA_ARGS__) } while (0)
+#define LOG4(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LINFO, false, false, __VA_ARGS__) } while (0)
+#define LOG5(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LDEBUG, false, false, __VA_ARGS__) } while (0)
+
+#define LOG11(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LNOTICE, false, true, __VA_ARGS__) } while (0)
+#define LOG21(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LERROR, false, true, __VA_ARGS__) } while (0)
+#define LOG31(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LWARNING, false, true, __VA_ARGS__) } while (0)
+#define LOG41(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LINFO, false, true, __VA_ARGS__) } while (0)
+#define LOG51(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LDEBUG, false, true, __VA_ARGS__) } while (0)
+
+#define NOTICE_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__) } while (0)
+#define ERROR_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__) } while (0)
+#define WARN_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__) } while (0)
+#define INFO_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__) } while (0)
+#define DEBUG_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) } while (0)
 
 #if MAX_LOGLEVEL >= DEBUG_LEVEL
 #define _dbg_assert_(_t_, _a_) \

--- a/Source/Core/Common/Src/Log.h
+++ b/Source/Core/Common/Src/Log.h
@@ -5,12 +5,6 @@
 #ifndef _LOG_H_
 #define _LOG_H_
 
-#define	NOTICE_LEVEL  1  // VERY important information that is NOT errors. Like startup and OSReports.
-#define	ERROR_LEVEL   2  // Critical errors 
-#define	WARNING_LEVEL 3  // Something is suspicious.
-#define	INFO_LEVEL    4  // General information.
-#define	DEBUG_LEVEL   5  // Detailed debugging - might make things slow.
-
 namespace LogTypes
 {
 
@@ -38,7 +32,7 @@ enum LOG_TYPE {
 	MEMMAP,
 	MEMCARD_MANAGER,
 	OSREPORT,
-	PAD, 
+	PAD,
 	PROCESSORINTERFACE,
 	PIXELENGINE,
 	SERIALINTERFACE,
@@ -64,12 +58,24 @@ enum LOG_TYPE {
 
 // FIXME: should this be removed?
 enum LOG_LEVELS {
-	LNOTICE = NOTICE_LEVEL,
-	LERROR = ERROR_LEVEL,
-	LWARNING = WARNING_LEVEL,
-	LINFO = INFO_LEVEL,
-	LDEBUG = DEBUG_LEVEL,
+	NOTICE // VERY important information that is NOT errors. Like startup and OSReports
+	, ERROR_ // Critical errors
+	, WARNING // Something is suspicious
+
+	, INFO // General information
+	, DEBUG // Detailed debugging - might make things slow
+
+	, COLOR_BEGIN
+	, BLUE
+	, CYAN
+	, MAGENTA
+	, GREY
+	, WHITE
 };
+
+#define LOGTYPES_WARNING 2
+#define LOGTYPES_INFO 3
+#define LOGTYPES_DEBUG 4
 
 #define LOGTYPES_LEVELS LogTypes::LOG_LEVELS
 #define LOGTYPES_TYPE LogTypes::LOG_TYPE
@@ -84,10 +90,10 @@ void GenericLog(LOGTYPES_LEVELS level, LOGTYPES_TYPE type,
 		;
 
 #if defined LOGGING || defined _DEBUG || defined DEBUGFAST
-#define MAX_LOGLEVEL DEBUG_LEVEL
+#define MAX_LOGLEVEL LOGTYPES_DEBUG
 #else
 #ifndef MAX_LOGLEVEL
-#define MAX_LOGLEVEL WARNING_LEVEL
+#define MAX_LOGLEVEL LOGTYPES_WARNING
 #endif // loglevel
 #endif // logging
 
@@ -96,31 +102,43 @@ void GenericLog(LOGTYPES_LEVELS level, LOGTYPES_TYPE type,
 #else
 // let the compiler optimization remove log levels
 #define GENERIC_LOG_(t, v, bf, bT, ...) { \
-	if (v <= MAX_LOGLEVEL) \
+	if (v <= MAX_LOGLEVEL || v > LogTypes::COLOR_BEGIN) \
 		GenericLog(v, t, bf, bT, __FILE__, __LINE__, __VA_ARGS__); \
 	}
 #endif
 #define GENERIC_LOG(t, v, ...) GENERIC_LOG_(t, v, true, true, __VA_ARGS__)
 
-#define LOG1(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LNOTICE, false, false, __VA_ARGS__) } while (0)
-#define LOG2(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LERROR, false, false, __VA_ARGS__) } while (0)
-#define LOG3(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LWARNING, false, false, __VA_ARGS__) } while (0)
-#define LOG4(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LINFO, false, false, __VA_ARGS__) } while (0)
-#define LOG5(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LDEBUG, false, false, __VA_ARGS__) } while (0)
+#define LOG1(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::NOTICE, false, false, __VA_ARGS__) } while (0)
+#define LOG2(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::ERROR_, false, false, __VA_ARGS__) } while (0)
+#define LOG3(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::WARNING, false, false, __VA_ARGS__) } while (0)
+#define LOG4(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::INFO, false, false, __VA_ARGS__) } while (0)
+#define LOG5(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::DEBUG, false, false, __VA_ARGS__) } while (0)
 
-#define LOG11(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LNOTICE, false, true, __VA_ARGS__) } while (0)
-#define LOG21(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LERROR, false, true, __VA_ARGS__) } while (0)
-#define LOG31(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LWARNING, false, true, __VA_ARGS__) } while (0)
-#define LOG41(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LINFO, false, true, __VA_ARGS__) } while (0)
-#define LOG51(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::LDEBUG, false, true, __VA_ARGS__) } while (0)
+#define LOG6(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::BLUE, false, false, __VA_ARGS__) } while (0)
+#define LOG7(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::CYAN, false, false, __VA_ARGS__) } while (0)
+#define LOG8(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::MAGENTA, false, false, __VA_ARGS__) } while (0)
+#define LOG9(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::GREY, false, false, __VA_ARGS__) } while (0)
+#define LOG10(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::WHITE, false, false, __VA_ARGS__) } while (0)
 
-#define NOTICE_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__) } while (0)
-#define ERROR_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__) } while (0)
-#define WARN_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__) } while (0)
-#define INFO_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__) } while (0)
-#define DEBUG_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) } while (0)
+#define LOG11(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::NOTICE, false, true, __VA_ARGS__) } while (0)
+#define LOG21(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::ERROR_, false, true, __VA_ARGS__) } while (0)
+#define LOG31(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::WARNING, false, true, __VA_ARGS__) } while (0)
+#define LOG41(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::INFO, false, true, __VA_ARGS__) } while (0)
+#define LOG51(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::DEBUG, false, true, __VA_ARGS__) } while (0)
 
-#if MAX_LOGLEVEL >= DEBUG_LEVEL
+#define LOG61(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::BLUE, false, true, __VA_ARGS__) } while (0)
+#define LOG71(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::CYAN, false, true, __VA_ARGS__) } while (0)
+#define LOG81(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::MAGENTA, false, true, __VA_ARGS__) } while (0)
+#define LOG91(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::GREY, false, true, __VA_ARGS__) } while (0)
+#define LOG101(t, ...) do { GENERIC_LOG_(LogTypes::t, LogTypes::WHITE, false, true, __VA_ARGS__) } while (0)
+
+#define NOTICE_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::NOTICE, __VA_ARGS__) } while (0)
+#define ERROR_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::ERROR_, __VA_ARGS__) } while (0)
+#define WARN_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::WARNING, __VA_ARGS__) } while (0)
+#define INFO_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::INFO, __VA_ARGS__) } while (0)
+#define DEBUG_LOG(t, ...) do { GENERIC_LOG(LogTypes::t, LogTypes::DEBUG, __VA_ARGS__) } while (0)
+
+#if MAX_LOGLEVEL > LOGTYPES_WARNING
 #define _dbg_assert_(_t_, _a_) \
 	if (!(_a_)) {\
 		ERROR_LOG(_t_, "Error...\n\n  Line: %d\n  File: %s\n  Time: %s\n\nIgnore and continue?", \

--- a/Source/Core/Common/Src/LogManager.cpp
+++ b/Source/Core/Common/Src/LogManager.cpp
@@ -113,7 +113,9 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
 	char msg[MAX_MSGLEN * 2];
 	LogContainer *log = m_Log[type];
 
-	if (!log->IsEnabled() || level > log->GetLevel() || ! log->HasListeners())
+	if (!log->IsEnabled()
+		|| (level > log->GetLevel() && level < LogTypes::COLOR_BEGIN)
+		|| ! log->HasListeners())
 		return;
 
 	CharArrayFromFormatV(temp, MAX_MSGLEN, format, args);
@@ -167,7 +169,7 @@ LogContainer::LogContainer(const char* shortName, const char* fullName, bool ena
 {
 	strncpy(m_fullName, fullName, 128);
 	strncpy(m_shortName, shortName, 32);
-	m_level = LogTypes::LWARNING;
+	m_level = LogTypes::WARNING;
 }
 
 // LogContainer

--- a/Source/Core/Common/Src/LogManager.cpp
+++ b/Source/Core/Common/Src/LogManager.cpp
@@ -14,13 +14,13 @@
 #include "FileUtil.h"
 
 void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, 
-		const char *file, int line, const char* fmt, ...)
+		bool logFile, bool logType, const char *file, int line, const char* fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
 	if (LogManager::GetInstance())
 		LogManager::GetInstance()->Log(level, type,
-			file, line, fmt, args);
+			logFile, logType, file, line, fmt, args);
 	va_end(args);
 }
 
@@ -107,7 +107,7 @@ LogManager::~LogManager()
 }
 
 void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, 
-	const char *file, int line, const char *format, va_list args)
+	bool logFile, bool logType, const char *file, int line, const char *format, va_list args)
 {
 	char temp[MAX_MSGLEN];
 	char msg[MAX_MSGLEN * 2];
@@ -119,13 +119,35 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
 	CharArrayFromFormatV(temp, MAX_MSGLEN, format, args);
 
 	static const char level_to_char[7] = "-NEWID";
-	sprintf(msg, "%s %s:%u %c[%s]: %s\n",
-		Common::Timer::GetTimeFormatted().c_str(),
-		file, line, level_to_char[(int)level],
-		log->GetShortName(), temp);
+	if (logFile && logType)
+		sprintf(msg, "%s %s:%d %c[%s] %s\n"
+			, Common::Timer::GetTimeFormatted().c_str()
+			, file
+			, line
+			, level_to_char[(int)level]
+			, log->GetShortName()
+			, temp);
+	else if (logFile)
+		sprintf(msg, "%s %s:%d %s\n"
+			, Common::Timer::GetTimeFormatted().c_str()
+			, file
+			, line
+			, temp);
+	else if (logType)
+		sprintf(msg, "%s %c[%s] %s\n"
+			, Common::Timer::GetTimeFormatted().c_str()
+			, level_to_char[(int)level]
+			, log->GetShortName()
+			, temp);
+	else
+		sprintf(msg, "%s %s\n"
+			, Common::Timer::GetTimeFormatted().c_str()
+			, temp);
+
 #ifdef ANDROID
 	Host_SysMessage(msg);	
 #endif
+
 	log->Trigger(level, msg);
 }
 

--- a/Source/Core/Common/Src/LogManager.h
+++ b/Source/Core/Common/Src/LogManager.h
@@ -100,7 +100,7 @@ public:
 	static u32 GetMaxLevel() { return MAX_LOGLEVEL;	}
 
 	void Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, 
-			 const char *file, int line, const char *fmt, va_list args);
+			bool logFile, bool logType, const char *file, int line, const char *fmt, va_list args);
 
 	void SetLogLevel(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level)
 	{

--- a/Source/Core/Core/Src/ActionReplay.cpp
+++ b/Source/Core/Core/Src/ActionReplay.cpp
@@ -228,7 +228,7 @@ void LogInfo(const char *format, ...)
 {
 	if (!b_RanOnce) 
 	{
-		if (LogManager::GetMaxLevel() >= LogTypes::LINFO || logSelf)
+		if (LogManager::GetMaxLevel() >= LogTypes::INFO || logSelf)
 		{
 			char* temp = (char*)alloca(strlen(format)+512);
 			va_list args;

--- a/Source/Core/Core/Src/Console.cpp
+++ b/Source/Core/Core/Src/Console.cpp
@@ -40,7 +40,7 @@ void Console_Submit(const char *cmd)
 
 		if (addr)
 		{
-#if MAX_LOGLEVEL >= INFO_LEVEL
+#if MAX_LOGLEVEL >= LOGTYPES_INFO
 			u32 EA =
 				Memory::TranslateAddress(addr, Memory::FLAG_NO_EXCEPTION);
 			INFO_LOG(CONSOLE, "EA 0x%08x to 0x%08x", addr, EA);

--- a/Source/Core/Core/Src/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Src/Debugger/Debugger_SymbolMap.cpp
@@ -36,7 +36,7 @@ void AddAutoBreakpoints()
 // Returns callstack "formatted for debugging" - meaning that it
 // includes LR as the last item, and all items are the last step,
 // instead of "pointing ahead"
-bool GetCallstack(std::vector<CallstackEntry> &output) 
+bool GetCallstack(std::vector<CallstackEntry> &output)
 {
 	if (Core::GetState() == Core::CORE_UNINITIALIZED)
 		return false;
@@ -91,9 +91,9 @@ void PrintCallstack()
 	u32 addr = Memory::ReadUnchecked_U32(PowerPC::ppcState.gpr[1]);  // SP
 
 	printf("== STACK TRACE - SP = %08x ==", PowerPC::ppcState.gpr[1]);
-	
+
 	if (LR == 0) {
-		printf(" LR = 0 - this is bad");	
+		printf(" LR = 0 - this is bad");
 	}
 	int count = 1;
 	if (g_symbolDB.GetDescription(PowerPC::ppcState.pc) != g_symbolDB.GetDescription(LR))
@@ -118,16 +118,16 @@ void PrintCallstack(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level)
 {
 	u32 addr = Memory::ReadUnchecked_U32(PowerPC::ppcState.gpr[1]);  // SP
 
-	GENERIC_LOG(type, level, "== STACK TRACE - SP = %08x ==", 
+	GENERIC_LOG(type, level, "== STACK TRACE - SP = %08x ==",
 				PowerPC::ppcState.gpr[1]);
 
 	if (LR == 0) {
-		GENERIC_LOG(type, level, " LR = 0 - this is bad");	
+		GENERIC_LOG(type, level, " LR = 0 - this is bad");
 	}
 	int count = 1;
 	if (g_symbolDB.GetDescription(PowerPC::ppcState.pc) != g_symbolDB.GetDescription(LR))
 	{
-		GENERIC_LOG(type, level, " * %s  [ LR = %08x ]", 
+		GENERIC_LOG(type, level, " * %s  [ LR = %08x ]",
 					g_symbolDB.GetDescription(LR), LR);
 		count++;
 	}
@@ -146,7 +146,7 @@ void PrintCallstack(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level)
 
 void PrintDataBuffer(LogTypes::LOG_TYPE type, u8* _pData, size_t _Size, const char* _title)
 {
-	GENERIC_LOG(type, LogTypes::LDEBUG, "%s", _title);		
+	GENERIC_LOG(type, LogTypes::DEBUG, "%s", _title);
 	for (u32 j = 0; j < _Size;)
 	{
 		std::string Temp;
@@ -159,7 +159,7 @@ void PrintDataBuffer(LogTypes::LOG_TYPE type, u8* _pData, size_t _Size, const ch
 			if (j >= _Size)
 				break;
 		}
-		GENERIC_LOG(type, LogTypes::LDEBUG, "   Data: %s", Temp.c_str());
+		GENERIC_LOG(type, LogTypes::DEBUG, "   Data: %s", Temp.c_str());
 	}
 }
 

--- a/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE.cpp
@@ -568,8 +568,8 @@ void Update()
 		request_queue.pop_front();
 		ExecuteCommand(command);
 
-#if MAX_LOGLEVEL >= DEBUG_LEVEL
-		Dolphin_Debugger::PrintCallstack(LogTypes::WII_IPC_HLE, LogTypes::LDEBUG);
+#if MAX_LOGLEVEL >= LOGTYPES_DEBUG
+		Dolphin_Debugger::PrintCallstack(LogTypes::WII_IPC_HLE, LogTypes::DEBUG);
 #endif
 	}
 

--- a/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE_Device.h
@@ -163,7 +163,7 @@ protected:
 	// of 4 byte commands.
 	void DumpCommands(u32 _CommandAddress, size_t _NumberOfCommands = 8,
 		LogTypes::LOG_TYPE LogType = LogTypes::WII_IPC_HLE,
-		LogTypes::LOG_LEVELS Verbosity = LogTypes::LDEBUG)
+		LogTypes::LOG_LEVELS Verbosity = LogTypes::DEBUG)
 	{
 		GENERIC_LOG(LogType, Verbosity, "CommandDump of %s", 
 					GetDeviceName().c_str());
@@ -176,7 +176,7 @@ protected:
 	
 	void DumpAsync(u32 BufferVector, u32 NumberInBuffer, u32 NumberOutBuffer,
 		LogTypes::LOG_TYPE LogType = LogTypes::WII_IPC_HLE,
-		LogTypes::LOG_LEVELS Verbosity = LogTypes::LDEBUG)
+		LogTypes::LOG_LEVELS Verbosity = LogTypes::DEBUG)
 	{
 		GENERIC_LOG(LogType, Verbosity, "======= DumpAsync ======");
 
@@ -186,7 +186,7 @@ protected:
 			u32 InBuffer        = Memory::Read_U32(BufferOffset); BufferOffset += 4;
 			u32 InBufferSize    = Memory::Read_U32(BufferOffset); BufferOffset += 4;
 
-			GENERIC_LOG(LogType, LogTypes::LINFO, "%s - IOCtlV InBuffer[%i]:",
+			GENERIC_LOG(LogType, LogTypes::INFO, "%s - IOCtlV InBuffer[%i]:",
 				GetDeviceName().c_str(), i);
 
 			std::string Temp;
@@ -197,7 +197,7 @@ protected:
 				Temp.append(Buffer);
 			}
 
-			GENERIC_LOG(LogType, LogTypes::LDEBUG, "    Buffer: %s", Temp.c_str());
+			GENERIC_LOG(LogType, LogTypes::DEBUG, "    Buffer: %s", Temp.c_str());
 		}
 
 		for (u32 i = 0; i < NumberOutBuffer; i++)
@@ -205,12 +205,12 @@ protected:
 			u32 OutBuffer        = Memory::Read_U32(BufferOffset); BufferOffset += 4;
 			u32 OutBufferSize    = Memory::Read_U32(BufferOffset); BufferOffset += 4;
 
-			GENERIC_LOG(LogType, LogTypes::LINFO, "%s - IOCtlV OutBuffer[%i]:",
+			GENERIC_LOG(LogType, LogTypes::INFO, "%s - IOCtlV OutBuffer[%i]:",
 				GetDeviceName().c_str(), i);
-			GENERIC_LOG(LogType, LogTypes::LINFO, "    OutBuffer: 0x%08x (0x%x):",
+			GENERIC_LOG(LogType, LogTypes::INFO, "    OutBuffer: 0x%08x (0x%x):",
 				OutBuffer, OutBufferSize);
 
-			#if defined(MAX_LOGLEVEL) && MAX_LOGLEVEL >= INFO_LEVEL
+			#if defined(MAX_LOGLEVEL) && MAX_LOGLEVEL >= LOGTYPES_INFO
 			DumpCommands(OutBuffer, OutBufferSize, LogType, Verbosity);
 			#endif
 		}

--- a/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -51,7 +51,7 @@ bool CWII_IPC_HLE_Device_usb_kbd::Write(u32 _CommandAddress)
 {
 	INFO_LOG(WII_IPC_STM, "Ignoring write to CWII_IPC_HLE_Device_usb_kbd");
 #if defined(_DEBUG) || defined(DEBUGFAST)
-	DumpCommands(_CommandAddress, 10, LogTypes::WII_IPC_STM, LogTypes::LDEBUG);
+	DumpCommands(_CommandAddress, 10, LogTypes::WII_IPC_STM, LogTypes::DEBUG);
 #endif
 	return true;
 }

--- a/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE_WiiMote.cpp
+++ b/Source/Core/Core/Src/IPC_HLE/WII_IPC_HLE_WiiMote.cpp
@@ -708,7 +708,7 @@ int ParseAttribList(u8* pAttribIDList, u16& _startID, u16& _endID)
 	u8 seqSize		= attribList.Read8(attribOffset);		attribOffset++;
 	u8 typeID		= attribList.Read8(attribOffset);		attribOffset++;
 
-#if MAX_LOGLEVEL >= DEBUG_LEVEL
+#if MAX_LOGLEVEL >= LOGTYPES_DEBUG
 	_dbg_assert_(WII_IPC_WIIMOTE, sequence == SDP_SEQ8);
 	(void)seqSize;
 #else

--- a/Source/Core/DiscIO/Src/WiiWad.cpp
+++ b/Source/Core/DiscIO/Src/WiiWad.cpp
@@ -100,7 +100,7 @@ bool WiiWAD::ParseWAD(DiscIO::IBlobReader& _rReader)
 	m_DataAppSize             = ReaderBig.Read32(0x18);
 	m_FooterSize              = ReaderBig.Read32(0x1C);
 
-#if MAX_LOGLEVEL >= DEBUG_LEVEL
+#if MAX_LOGLEVEL >= LOGTYPES_DEBUG
 	_dbg_assert_msg_(BOOT, Reserved==0x00, "WiiWAD: Reserved must be 0x00");
 #else
 	(void)Reserved;

--- a/Source/Core/DolphinWX/Src/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/Src/LogConfigWindow.cpp
@@ -33,7 +33,7 @@ void LogConfigWindow::CreateGUIControls()
 	wxLevels.Add(_("Warning"));
 	wxLevels.Add(_("Info"));
 	wxLevels.Add(_("Debug"));
-	for (int i = 0; i < MAX_LOGLEVEL; ++i)
+	for (int i = 0; i <= MAX_LOGLEVEL; ++i)
 		wxLevelsUse.Add(wxLevels[i]);
 	m_verbosity = new wxRadioBox(this, wxID_ANY, _("Verbosity"),
 			wxDefaultPosition, wxDefaultSize, wxLevelsUse, 0,
@@ -103,13 +103,13 @@ void LogConfigWindow::LoadSettings()
 	ini.Get("Options", "Verbosity", &verbosity, 0);
 	
 	// Ensure the verbosity level is valid.
-	if (verbosity < 1)
-		verbosity = 1;
+	if (verbosity < 0)
+		verbosity = 0;
 	if (verbosity > MAX_LOGLEVEL)
 		verbosity = MAX_LOGLEVEL;
 	
 	// Actually set the logging verbosity.
-	m_verbosity->SetSelection(verbosity - 1);
+	m_verbosity->SetSelection(verbosity);
 
 	// Get the logger output settings from the config ini file.
 	ini.Get("Options", "WriteToFile", &m_writeFile, false);
@@ -150,7 +150,7 @@ void LogConfigWindow::SaveSettings()
 	ini.Load(File::GetUserPath(F_LOGGERCONFIG_IDX));
 
 	// Save the verbosity level.
-	ini.Set("Options", "Verbosity", m_verbosity->GetSelection() + 1);
+	ini.Set("Options", "Verbosity", m_verbosity->GetSelection());
 
 	// Save the enabled/disabled states of the logger outputs to the config ini.
 	ini.Set("Options", "WriteToFile", m_writeFile);

--- a/Source/Core/DolphinWX/Src/LogWindow.cpp
+++ b/Source/Core/DolphinWX/Src/LogWindow.cpp
@@ -53,8 +53,8 @@ void CLogWindow::CreateGUIControls()
 	ini.Get("Options", "Verbosity", &verbosity, 0);
 	
 	// Ensure the verbosity level is valid
-	if (verbosity < 1)
-		verbosity = 1;
+	if (verbosity < 0)
+		verbosity = 0;
 	if (verbosity > MAX_LOGLEVEL)
 		verbosity = MAX_LOGLEVEL;
 
@@ -302,26 +302,43 @@ void CLogWindow::UpdateLog()
 		{
 			switch (msgQueue.front().first)
 			{
-				case ERROR_LEVEL:
+				case LogTypes::ERROR_:
 					m_Log->SetDefaultStyle(wxTextAttr(*wxRED));
 					break;
-				
-				case WARNING_LEVEL:
-					m_Log->SetDefaultStyle(wxTextAttr(wxColour(255, 255, 0))); // YELLOW
+
+				case LogTypes::WARNING:
+					m_Log->SetDefaultStyle(wxTextAttr(*wxYELLOW));
 					break;
-				
-				case NOTICE_LEVEL:
+
+				case LogTypes::NOTICE:
 					m_Log->SetDefaultStyle(wxTextAttr(*wxGREEN));
 					break;
-				
-				case INFO_LEVEL:
+
+				case LogTypes::INFO:
 					m_Log->SetDefaultStyle(wxTextAttr(*wxCYAN));
 					break;
-				
-				case DEBUG_LEVEL:
+
+				case LogTypes::DEBUG:
 					m_Log->SetDefaultStyle(wxTextAttr(*wxLIGHT_GREY));
 					break;
-				
+
+				case LogTypes::BLUE:
+					m_Log->SetDefaultStyle(wxTextAttr(wxColour(128, 128, 255)));
+					break;
+
+				case LogTypes::CYAN:
+					m_Log->SetDefaultStyle(wxTextAttr(*wxCYAN));
+					break;
+
+				case LogTypes::MAGENTA:
+					m_Log->SetDefaultStyle(wxTextAttr(wxColour(255, 0, 255)));
+					break;
+
+				case LogTypes::GREY:
+					m_Log->SetDefaultStyle(wxTextAttr(*wxLIGHT_GREY));
+					break;
+
+				case LogTypes::WHITE:
 				default:
 					m_Log->SetDefaultStyle(wxTextAttr(*wxWHITE));
 					break;


### PR DESCRIPTION
## Adding option to log without file or type
### Problem

When printing
- hex dumps (f.e. from a Wiimote)
- series of data f.e.
  - formatted Wiimote date
  - Gecko code log

the file and type prefix
- isn't meaningful
- use horisontal space

this example show
- a file and type prefix that's 50 letters
- an indentation offset of 1 letter because the row number is different

<!-- -->

```
10:34:860 Src\HW\WiimoteReal\WiimoteReal.cpp:379 N[Wiimote]: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
10:34:861 Src\HW\WiimoteReal\WiimoteReal.cpp:79 N[Wiimote]: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```

This is a problem because
- it use space i.o.w. leave less room for the log
- it alters the indentation length when there's a difference in
  - number of letters in the row number
  - file path
- it's slower to locate to locate the beginning of log text when
  - there's preceding text that's not different in apperance f.e. color
  - the indentation length is varaible
### Solution

Adding a log without file prefix, that print this instead of the above

```
10:34:860 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
10:34:861 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```
### Function name

The log name is
- LOG#: exclude file and type
- LOG#1: exclude file

because
- fast to type becuse it's short
- the color number 1, 2, 3, 4, 5 is easier to remember than N, W, E, I, D
### Punctuation

The punctuation is changed from

```
12:35:014 Src\File.cpp:350 N[COMMON]: test 1
```

to

```
12:35:014 Src\File.cpp:350 N[COMMON] test 1
```

because
- that use less horisontal space
- the colon separator isn't meaningful to indicate where the log message start because it can be inferred from the format of the log
### Log selection

> [15:19] <_skidau> yeh, i think the log file name is quite redundant, but other people like it, so don't merge the patch

It doesn't alter the current log f.e. `WARN_LOG`, it adds f.e. a `WARN_LOG_S`

> [15:29] <_skidau> hmm.. i don't like it, sorry :P

Describe the reason for that

> [15:34] <_skidau> the confusion of "why are there two ways to log"

Because
- non-text data is more efficient to print without a file and type prefix because row length and fixed indentation length matters
- some logging is temporary in the sense that it's removed when a problem is solved
- for this logging it's valuable to grant different preferences regarding file and type prefix
### Identify log origin

> [15:45] @Sonicadvance1 And then on that point. If they are left in the source and they accumulate, it can very well turn in to a clusterfuck of "Where are these messages coming from?"

When committing a log without file prefix it's appropriate to prepend it with a log that describe the source of f.e. the following hex dump because it would otherwise have little meaning for the reader
### Value

> [16:15] @Sonicadvance1 This seems to be a very specific change that will be used in just a singular location
> [16:15] @Sonicadvance1 eg, You debugging wiimote dumps

Hex dumps are important for emulation and reverse engineering and the emulator should have
- a log function without a file and type prefix
- a hex dump function that print a C array (i.o.w. the output format of `xxd -i`)

> [16:32] @Sonicadvance1 I think that is called printf

The problem with `printf` is
- it isn't printed in Windows in origin
- it's printed in Windows in a commit in https://github.com/mirror/dolphin-emu/pull/1 but it's not merged
