### PR TITLE
Adding AA, AF, video backend to iso properties

### DIFF
--- a/Source/Core/Common/Src/VideoBackendBase.h
+++ b/Source/Core/Common/Src/VideoBackendBase.h
@@ -98,6 +98,7 @@ public:
 	virtual std::string GetName() = 0;
 
 	virtual void ShowConfig(void*) {}
+	virtual void InitBackendInfo() {}
 
 	virtual void Video_Prepare() = 0;
 	virtual void Video_EnterLoop() = 0;

--- a/Source/Core/Core/Src/BootManager.cpp
+++ b/Source/Core/Core/Src/BootManager.cpp
@@ -29,9 +29,6 @@
 //               Boot.cpp               CBoot::BootUp()
 //                                      CBoot::EmulatedBS2_Wii() / GC() or Load_BS2()
 
-
-// Includes
-// ----------------
 #include <string>
 #include <vector>
 
@@ -47,7 +44,6 @@
 #include "VideoBackendBase.h"
 #include "Movie.h"
 
-
 namespace BootManager
 {
 
@@ -59,6 +55,7 @@ struct ConfigCache
 		bVBeam, bFastDiscSpeed, bMergeBlocks, bDSPHLE, bDisableWiimoteSpeaker;
 	int iTLBHack;
 	std::string strBackend;
+	std::string m_strVideoBackend;
 };
 static ConfigCache config_cache;
 
@@ -88,6 +85,7 @@ bool BootCore(const std::string& _rFilename)
 	if (unique_id.size() == 6 && game_ini.Load(StartUp.m_strGameIni.c_str()))
 	{
 		config_cache.valid = true;
+		config_cache.m_strVideoBackend = StartUp.m_strVideoBackend;
 		config_cache.bCPUThread = StartUp.bCPUThread;
 		config_cache.bSkipIdle = StartUp.bSkipIdle;
 		config_cache.bEnableFPRF = StartUp.bEnableFPRF;
@@ -102,6 +100,7 @@ bool BootCore(const std::string& _rFilename)
 		config_cache.strBackend = StartUp.m_strVideoBackend;
 
 		// General settings
+		game_ini.Get("Core", "GFXBackend",			&StartUp.m_strVideoBackend, StartUp.m_strVideoBackend.c_str());
 		game_ini.Get("Core", "CPUThread",			&StartUp.bCPUThread, StartUp.bCPUThread);
 		game_ini.Get("Core", "SkipIdle",			&StartUp.bSkipIdle, StartUp.bSkipIdle);
 		game_ini.Get("Core", "EnableFPRF",			&StartUp.bEnableFPRF, StartUp.bEnableFPRF);
@@ -114,6 +113,7 @@ bool BootCore(const std::string& _rFilename)
 		game_ini.Get("Core", "DSPHLE",				&StartUp.bDSPHLE, StartUp.bDSPHLE);
 		game_ini.Get("Wii", "DisableWiimoteSpeaker",&StartUp.bDisableWiimoteSpeaker, StartUp.bDisableWiimoteSpeaker);
 		game_ini.Get("Core", "GFXBackend", &StartUp.m_strVideoBackend, StartUp.m_strVideoBackend.c_str());
+
 		VideoBackend::ActivateBackend(StartUp.m_strVideoBackend);
 
 		if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
@@ -158,6 +158,7 @@ void Stop()
 	if (config_cache.valid)
 	{
 		config_cache.valid = false;
+		StartUp.m_strVideoBackend = config_cache.m_strVideoBackend;
 		StartUp.bCPUThread = config_cache.bCPUThread;
 		StartUp.bSkipIdle = config_cache.bSkipIdle;
 		StartUp.bEnableFPRF = config_cache.bEnableFPRF;
@@ -170,6 +171,7 @@ void Stop()
 		StartUp.bDSPHLE = config_cache.bDSPHLE;
 		StartUp.bDisableWiimoteSpeaker = config_cache.bDisableWiimoteSpeaker;
 		StartUp.m_strVideoBackend = config_cache.strBackend;
+
 		VideoBackend::ActivateBackend(StartUp.m_strVideoBackend);
 	}
 }

--- a/Source/Core/Core/Src/Core.cpp
+++ b/Source/Core/Core/Src/Core.cpp
@@ -390,6 +390,7 @@ void EmuThread()
 
 	HW::Init();	
 
+	VideoBackend::ActivateBackend(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strVideoBackend);
 	if (!g_video_backend->Initialize(g_pWindowHandle))
 	{
 		PanicAlert("Failed to initialize video backend!");

--- a/Source/Core/DolphinWX/Src/FrameTools.cpp
+++ b/Source/Core/DolphinWX/Src/FrameTools.cpp
@@ -1209,6 +1209,7 @@ void CFrame::OnConfigMain(wxCommandEvent& WXUNUSED (event))
 
 void CFrame::OnConfigGFX(wxCommandEvent& WXUNUSED (event))
 {
+	VideoBackend::ActivateBackend(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strVideoBackend);
 	if (g_video_backend)
 		g_video_backend->ShowConfig(this);
 }

--- a/Source/Core/DolphinWX/Src/ISOProperties.h
+++ b/Source/Core/DolphinWX/Src/ISOProperties.h
@@ -36,6 +36,10 @@
 #include "PatchEngine.h"
 #include "ActionReplay.h"
 #include "GeckoCodeDiag.h"
+#include "VideoBackendBase.h"
+#include "VideoConfig.h"
+
+extern VideoConfig g_Config;
 
 struct PHackData
 {
@@ -68,7 +72,9 @@ public:
 private:
 	DECLARE_EVENT_TABLE();
 
+	wxNotebook* m_Notebook;
 	// Core
+	wxChoice *choice_backend, *choice_aa, *choice_af;
 	wxCheckBox *CPUThread, *SkipIdle, *MMU, *MMUBAT, *TLBHack;
 	wxCheckBox *VBeam, *FastDiscSpeed, *BlockMerging, *DSPHLE;
 	// Wii
@@ -207,6 +213,7 @@ private:
 	IniFile GameIni;
 	std::string GameIniFile;
 
+	void UpdateUIGameConfig(wxCommandEvent& event); void UpdateUIGameConfig();
 	void LoadGameConfig();
 	void PatchList_Load();
 	void PatchList_Save();

--- a/Source/Plugins/Plugin_VideoDX11/Src/VideoBackend.h
+++ b/Source/Plugins/Plugin_VideoDX11/Src/VideoBackend.h
@@ -17,6 +17,7 @@ class VideoBackend : public VideoBackendHardware
 	void Video_Prepare();
 
 	void ShowConfig(void* parent);
+	void InitBackendInfo();
 
 	void UpdateFPSDisplay(const char*);
 	unsigned int PeekMessages();

--- a/Source/Plugins/Plugin_VideoDX11/Src/main.cpp
+++ b/Source/Plugins/Plugin_VideoDX11/Src/main.cpp
@@ -78,7 +78,7 @@ std::string VideoBackend::GetName()
 	return "Direct3D11";
 }
 
-void InitBackendInfo()
+void VideoBackend::InitBackendInfo()
 {
 	HRESULT hr = DX11::D3D::LoadDXGI();
 	if (SUCCEEDED(hr)) hr = DX11::D3D::LoadD3D();

--- a/Source/Plugins/Plugin_VideoDX9/Src/VideoBackend.h
+++ b/Source/Plugins/Plugin_VideoDX9/Src/VideoBackend.h
@@ -17,6 +17,7 @@ class VideoBackend : public VideoBackendHardware
 	void Video_Prepare();
 
 	void ShowConfig(void* parent);
+	void InitBackendInfo();
 
 	void UpdateFPSDisplay(const char*);
 	unsigned int PeekMessages();

--- a/Source/Plugins/Plugin_VideoDX9/Src/main.cpp
+++ b/Source/Plugins/Plugin_VideoDX9/Src/main.cpp
@@ -86,7 +86,7 @@ std::string VideoBackend::GetName()
 	return "Direct3D9";
 }
 
-void InitBackendInfo()
+void VideoBackend::InitBackendInfo()
 {
 	DX9::D3D::Init();
 	const int shaderModel = ((DX9::D3D::GetCaps().PixelShaderVersion >> 8) & 0xFF);

--- a/Source/Plugins/Plugin_VideoOGL/Src/VideoBackend.h
+++ b/Source/Plugins/Plugin_VideoOGL/Src/VideoBackend.h
@@ -17,6 +17,7 @@ class VideoBackend : public VideoBackendHardware
 	void Video_Prepare();
 
 	void ShowConfig(void* parent);
+	void InitBackendInfo();
 
 	void UpdateFPSDisplay(const char*);
 	unsigned int PeekMessages();

--- a/Source/Plugins/Plugin_VideoOGL/Src/main.cpp
+++ b/Source/Plugins/Plugin_VideoOGL/Src/main.cpp
@@ -127,7 +127,7 @@ void GetShaders(std::vector<std::string> &shaders)
         }
 }
 
-void InitBackendInfo()
+void VideoBackend::InitBackendInfo()
 {
 	g_Config.backend_info.APIType = API_OPENGL;
 	g_Config.backend_info.bUseRGBATextures = false;


### PR DESCRIPTION
## Adding AA, AF, video backend to iso properties
### Discussion

[@kostamar](https://code.google.com/p/dolphin-emu/issues/detail?id=5041)

The Red Steel 2 [OpenGL] backend setting is removed because of this information

@NeoBrainX

> - Will the gfx backend setting work on Linux if Direct3D is specified as the game specific option or will that cause a segfault?

The gfx backend iso property takes the backends from the same list as videoconfig so there is no D3D option in linux

> Please don't make more use of the _connect_macro_ mess, it's awkward and plain wx connections should be used instead

I request that a consensus is demonstrated for this opinion because
- it's used elsewhere
- it's not clear why it's not beneficial
