### PR TITLE
Fixing or disabling the "Download Codes (WiiRD Database)" button

### DIFF
--- a/Source/Core/DolphinWX/Src/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Src/CheatsWindow.cpp
@@ -39,7 +39,7 @@ wxCheatsWindow::wxCheatsWindow(wxWindow* const parent)
 	{
 		m_gameini_path = File::GetUserPath(D_GAMECONFIG_IDX) + vol->GetUniqueID() + ".ini";
 		m_gameini.Load(m_gameini_path);
-		m_geckocode_panel->LoadCodes(m_gameini);
+		m_geckocode_panel->LoadCodes(m_gameini, Core::g_CoreStartupParameter.GetUniqueID());
 	}
 	}
 

--- a/Source/Core/DolphinWX/Src/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/Src/GeckoCodeDiag.cpp
@@ -41,7 +41,8 @@ CodeConfigPanel::CodeConfigPanel(wxWindow* const parent)
 
 	// button sizer
 	wxBoxSizer* const sizer_buttons = new wxBoxSizer(wxHORIZONTAL);
-	wxButton* const btn_download = new wxButton(this, -1, _("Download Codes (WiiRD Database)"), wxDefaultPosition, wxSize(128, -1));
+	btn_download = new wxButton(this, -1, _("Download Codes (WiiRD Database)"), wxDefaultPosition, wxSize(128, -1));
+	btn_download->Enable(false);
 	btn_download->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &CodeConfigPanel::DownloadCodes, this);
 	sizer_buttons->AddStretchSpacer(1);
 	sizer_buttons->Add(btn_download, 1, wxEXPAND);
@@ -60,6 +61,9 @@ CodeConfigPanel::CodeConfigPanel(wxWindow* const parent)
 
 void CodeConfigPanel::UpdateCodeList()
 {
+	// disable the button if it doesn't have an effect
+	btn_download->Enable(!m_gameid.empty());	
+
 	m_listbox_gcodes->Clear();
 	// add the codes to the listbox
 	std::vector<GeckoCode>::const_iterator

--- a/Source/Core/DolphinWX/Src/GeckoCodeDiag.h
+++ b/Source/Core/DolphinWX/Src/GeckoCodeDiag.h
@@ -44,7 +44,7 @@ private:
 		wxTextCtrl		*textctrl_notes;
 		wxListBox	*listbox_codes;
 	} m_infobox;
-
+	wxButton* btn_download;
 };
 
 


### PR DESCRIPTION
## Fixing or disabling the "Download Codes (WiiRD Database)" button
### Related patch idea

> [17:24] <_RachelB> JPeterson: any reason you didn't just make the download codes button work?
> [17:29] <_RachelB> JPeterson: looks like you just need to grab the game ID from Core::g_CoreStartupParameter.GetUniqueID()
> [17:36] <_RachelB> JPeterson: i fixed it

what does that mean?

> [17:38] <_RachelB> JPeterson: it means i have found a solution that allows it to properly download gecko codes from the cheat manager

I would advise against committing that if
- the patch is a different solution to a suggested patch (which this patch might be)

without discussing it (including showing a potentially competing patch) with the author of the potentially similar idea, because

the authorship might not be clear because
- similarities in idea or code (as determined by f.e. `wdiff`) will introduce ambiguity regarding authorship
- even if the competing solution is unique compared to the first solution, the problem formulation in the first solution might count as authorship in the competing solution if it lead to the competing solution

if the authorship is clear (the competing solution contain no idea or code from the first solution) and the competing solution is selected as the right solution (over the first solution) it's still appropriate to explain thoroughly to the author of the first solution why this author will not receive authorship credit for the selected solution, before the solution is committed, because it's not clear that the author of the first solution otherwise will understand that a reasoned discussion lead to the rejection of the first solution
