### PR TITLE
Adding batch build files

### DIFF
--- a/Source/build.all.bat
+++ b/Source/build.all.bat
@@ -1,0 +1,1 @@
+call build.proj /t:Build

--- a/Source/build.bat
+++ b/Source/build.bat
@@ -1,0 +1,15 @@
+REM exception
+@if "%~1" equ "" (
+	@echo off
+	call shared color c "This file should be run from f.e. 'build.release.64.bat' instead"
+	pause
+	exit /b %ERRORLEVEL%
+)
+
+REM build
+call env
+msbuild Dolphin_2010.sln %*
+@if %ERRORLEVEL% neq 0 (
+	pause
+	exit /b %ERRORLEVEL%
+)

--- a/Source/build.debug.32.bat
+++ b/Source/build.debug.32.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Debug /p:Configuration=Release;Platform=Win32

--- a/Source/build.debug.64.bat
+++ b/Source/build.debug.64.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Debug /p:Configuration=Release;Platform=x64

--- a/Source/build.debugfast.32.bat
+++ b/Source/build.debugfast.32.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin /p:Configuration=DebugFast;Platform=Win32

--- a/Source/build.debugfast.64.bat
+++ b/Source/build.debugfast.64.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin /p:Configuration=DebugFast;Platform=x64

--- a/Source/build.proj.bat
+++ b/Source/build.proj.bat
@@ -1,0 +1,15 @@
+REM exception
+@if "%~1" equ "" (
+	@echo off
+	call shared color c "This file should be run from 'build.all.bat' or 'clean.bat' instead"
+	pause
+	exit /b %ERRORLEVEL%
+)
+
+REM build
+call env
+msbuild msbuild.proj %*
+@if %ERRORLEVEL% neq 0 (
+	pause
+	exit /b %ERRORLEVEL%
+)

--- a/Source/build.release.32.bat
+++ b/Source/build.release.32.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin /p:Configuration=Release;Platform=Win32

--- a/Source/build.release.64.bat
+++ b/Source/build.release.64.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin /p:Configuration=Release;Platform=x64

--- a/Source/clean.bat
+++ b/Source/clean.bat
@@ -1,0 +1,1 @@
+call build.proj /t:Clean

--- a/Source/env.bat
+++ b/Source/env.bat
@@ -1,0 +1,1 @@
+call "%VS100COMNTOOLS%..\..\vc\vcvarsall.bat"

--- a/Source/msbuild.proj
+++ b/Source/msbuild.proj
@@ -1,0 +1,32 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<Solution Include="Dolphin_2010.sln"/>
+	</ItemGroup>
+
+	<Target Name="Build">
+		<MSBuild Projects="@(Solution)" Targets="Dolphin" Properties="Configuration=Release;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin" Properties="Configuration=Release;Platform=Win32"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin" Properties="Configuration=DebugFast;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin" Properties="Configuration=DebugFast;Platform=Win32"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin" Properties="Configuration=Debug;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin" Properties="Configuration=Debug;Platform=Win32"/>
+	</Target>
+	
+	<Target Name="Rebuild">
+		<MSBuild Projects="@(Solution)" Targets="Dolphin:Rebuild" Properties="Configuration=Release;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin:Rebuild" Properties="Configuration=Release;Platform=Win32"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin:Rebuild" Properties="Configuration=DebugFast;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin:Rebuild" Properties="Configuration=DebugFast;Platform=Win32"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin:Rebuild" Properties="Configuration=Debug;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Dolphin:Rebuild" Properties="Configuration=Debug;Platform=Win32"/>
+	</Target>
+	
+	<Target Name="Clean">
+		<MSBuild Projects="@(Solution)" Targets="Clean" Properties="Configuration=Release;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Clean" Properties="Configuration=Release;Platform=Win32"/>
+		<MSBuild Projects="@(Solution)" Targets="Clean" Properties="Configuration=DebugFast;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Clean" Properties="Configuration=DebugFast;Platform=Win32"/>
+		<MSBuild Projects="@(Solution)" Targets="Clean" Properties="Configuration=Debug;Platform=x64"/>
+		<MSBuild Projects="@(Solution)" Targets="Clean" Properties="Configuration=Debug;Platform=Win32"/>
+	</Target>
+</Project>

--- a/Source/rebuild.all.bat
+++ b/Source/rebuild.all.bat
@@ -1,0 +1,1 @@
+call build.proj /t:Rebuild

--- a/Source/rebuild.debug.32.bat
+++ b/Source/rebuild.debug.32.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Rebuild /p:Configuration=Debug;Platform=Win32

--- a/Source/rebuild.debug.64.bat
+++ b/Source/rebuild.debug.64.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Rebuild /p:Configuration=Debug;Platform=x64

--- a/Source/rebuild.debugfast.32.bat
+++ b/Source/rebuild.debugfast.32.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Rebuild /p:Configuration=DebugFast;Platform=Win32

--- a/Source/rebuild.debugfast.64.bat
+++ b/Source/rebuild.debugfast.64.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Rebuild /p:Configuration=DebugFast;Platform=x64

--- a/Source/rebuild.release.32.bat
+++ b/Source/rebuild.release.32.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Rebuild /p:Configuration=Release;Platform=Win32

--- a/Source/rebuild.release.64.bat
+++ b/Source/rebuild.release.64.bat
@@ -1,0 +1,1 @@
+call build /t:Dolphin:Rebuild /p:Configuration=Release;Platform=x64

--- a/Source/shared.bat
+++ b/Source/shared.bat
@@ -1,0 +1,26 @@
+REM shared code
+
+REM exception
+@if "%~1" equ "" (
+	@echo off
+	call shared color c "This file should be run from another file"
+	pause
+	exit /b %ERRORLEVEL%
+)
+
+REM call function
+call :%*
+exit /b
+
+REM color text
+:color
+@echo off
+setlocal
+pushd %temp%
+for /F "tokens=1 delims=#" %%a in ('"prompt #$H#$E# & echo on & for %%b in (1) do rem"') do (
+	<nul set/p"=%%a" >"%~2"
+)
+findstr /v /a:%1 /R "^$" "%~2" nul
+del "%~2" > nul 2>&1
+popd
+@echo on


### PR DESCRIPTION
## Adding batch build files
### Build script

Build scripts are added because
- bulding from a command is fasther than opening the VS window and builiding from it
- if VS the window is already open, building another (or all) configuration than the one selected in the GUI is faster to do from a command than selecting it in the window
### Discussion

@delroth

> Why not use msbuild instead of calling devenv?

Fixed

> Also, please put all the scripts in a subdirectory to avoid having a lot of files in Source/.

The files should be in the same path as "Dolphin_2010.sln" because
- it means less navigation in explorer to run the most common files; "Dolphin_2010.sln", "build.debugfast.64.bat", "build.release.64.bat" from the same path
- the files .bat, .proj, .sln have a common purpose (define the build) and should therefore be organised in the same folder
- other have this opinion, f.e. the .bat and .sln is in the same path in https://github.com/mpc-hc/mpc-hc
