### PR TITLE
Changing PostBuildEvent from xcopy to robocopy

### DIFF
--- a/Source/Core/DolphinWX/Dolphin.vcxproj
+++ b/Source/Core/DolphinWX/Dolphin.vcxproj
@@ -164,7 +164,7 @@ xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /
     </ClCompile>
     <Link />
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)..\Data" "$(TargetDir)" /e /s /y /d
+      <Command>robocopy "$(SolutionDir)..\Data" "$(TargetDir)" /s /xo
 echo Copying External .dlls
 xcopy "$(SolutionDir)..\Externals\OpenAL\Win32\*.dll" "$(TargetDir)" /e /s /y /q /d
 xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /s /y /q /d
@@ -178,7 +178,7 @@ xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /
     </ClCompile>
     <Link />
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)..\Data" "$(TargetDir)" /e /s /y /d
+      <Command>robocopy "$(SolutionDir)..\Data" "$(TargetDir)" /s /xo
 echo Copying External .dlls
 xcopy "$(SolutionDir)..\Externals\OpenAL\Win32\*.dll" "$(TargetDir)" /e /s /y /q /d
 xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /s /y /q /d
@@ -194,7 +194,7 @@ xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /
     </ClCompile>
     <Link />
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)..\Data" "$(TargetDir)" /e /s /y /d
+      <Command>robocopy "$(SolutionDir)..\Data" "$(TargetDir)" /s /xo
 echo Copying External .dlls
 xcopy "$(SolutionDir)..\Externals\OpenAL\Win64\*.dll" "$(TargetDir)" /e /s /y /q /d
 xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /s /y /q /d
@@ -210,7 +210,7 @@ xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /
     </ClCompile>
     <Link />
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)..\Data" "$(TargetDir)" /e /s /y /d
+      <Command>robocopy "$(SolutionDir)..\Data" "$(TargetDir)" /s /xo
 echo Copying External .dlls
 xcopy "$(SolutionDir)..\Externals\OpenAL\Win64\*.dll" "$(TargetDir)" /e /s /y /q /d
 xcopy "$(SolutionDir)..\Externals\SDL\$(PlatformName)\*.dll" "$(TargetDir)" /e /s /y /q /d


### PR DESCRIPTION
## Changing PostBuildEvent from xcopy to robocopy
### Robocopy rather than xcopy

Create the problem with

```
# create junction in dolphin.exe path
mklink /j user c:\dolphin\data\user

# overwrite older with newer settings files
xcopy "$(SolutionDir)..\Data" "$(TargetDir)" /e /s /y /d
robocopy "$(SolutionDir)..\Data" "$(TargetDir)" /s /xo
```

the `xcopy /e /s /y /d` command overwrite the "user" junction with the "Data" folder

the `junction` command treat the junction as a folder
### Discussion

> [03:04] @Sonicadvance1 JPeterson, Is robocopy provided default on Windows XP machines when they install Visual Studio?

No the first Windows version with `System32\Robocopy.exe` is 6.0

> [03:21] @Jasper We care about XP?
