### PR TITLE
Changing the recompilation viewer to always be updated

### DIFF
--- a/Source/Core/DolphinWX/Src/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Src/Debugger/CodeView.cpp
@@ -26,7 +26,6 @@ enum
 	IDM_COPYCODE,
 	IDM_INSERTBLR, IDM_INSERTNOP,
 	IDM_RUNTOHERE,
-	IDM_JITRESULTS,
 	IDM_FOLLOWBRANCH,
 	IDM_RENAMESYMBOL,
 	IDM_PATCHALERT,
@@ -76,6 +75,9 @@ int CCodeView::YToAddress(int y)
 
 void CCodeView::OnMouseDown(wxMouseEvent& event)
 {
+	if (!debugger->isAlive())
+		return;
+
 	int x = event.m_x;
 	int y = event.m_y;
 
@@ -86,6 +88,7 @@ void CCodeView::OnMouseDown(wxMouseEvent& event)
 		// SetCapture(wnd);
 		bool oldselecting = selecting;
 		selecting = true;
+		debugger->showJitResults(selection);
 
 		if (!oldselecting || (selection != oldSelection))
 			Refresh();
@@ -268,10 +271,6 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 			InsertBlrNop(1);
 			Refresh();
 			break;
-
-		case IDM_JITRESULTS:
-			debugger->showJitResults(selection);
-			break;
 			
 		case IDM_FOLLOWBRANCH:
 			{
@@ -335,7 +334,6 @@ void CCodeView::OnMouseUpR(wxMouseEvent& event)
 	menu->AppendSeparator();
 	menu->Append(IDM_RUNTOHERE, _("&Run To Here"));
 	menu->Append(IDM_ADDFUNCTION, _("&Add function"));
-	menu->Append(IDM_JITRESULTS, StrToWxStr("PPC vs X86"));
 	menu->Append(IDM_INSERTBLR, StrToWxStr("Insert &blr"));
 	menu->Append(IDM_INSERTNOP, StrToWxStr("Insert &nop"));
 	menu->Append(IDM_PATCHALERT, StrToWxStr("Patch alert"));

--- a/Source/Core/DolphinWX/Src/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Src/Debugger/CodeView.h
@@ -47,6 +47,8 @@ public:
 	{
 		curAddress = addr;
 		selection = addr;
+		if (debugger->isAlive())
+			debugger->showJitResults(selection);
 		Refresh();
 	}
 


### PR DESCRIPTION
## Changing the recompilation viewer to always be updated
### Problem

When recompilation is inspected by
- showing the "JIT block viewer" and "Code" panels
- stepping
- selecting code in "Code"

the recompilation code comparison is shown with "right click → PPC vs X 86"

This is inefficient because
- it's unnecessary to require action for this
### Solution

Changing the recompilation viewer to always be updated
### Discussion

> [22:07] @Sonicadvance1 JPeterson, What if I don't want to view PPC->X86?

The patch doesn't have an option to step or select a code row in the "Code" window without updating the "JIT block viewer" window because
- there's no common scenario where it's meaningful

If the "JIT block viewer" window isn't enabled it isn't updated

> [22:46] @Sonicadvance1 JPeterson, eh?

Is the argument less clear than it can be?

> [22:56] @Sonicadvance1 JPeterson, The change makes it so the PPC->X86 view is always on right?

no the change is that it's always updated (if it's enabled)
