### PR TITLE
Adding menu option to switch between debugging and default GUI

### DIFF
--- a/Source/Core/DolphinWX/Src/Frame.cpp
+++ b/Source/Core/DolphinWX/Src/Frame.cpp
@@ -190,6 +190,7 @@ EVT_MENU(IDM_MEMCARD, CFrame::OnMemcard)
 EVT_MENU(IDM_IMPORTSAVE, CFrame::OnImportSave)
 EVT_MENU(IDM_CHEATS, CFrame::OnShow_CheatsWindow)
 EVT_MENU(IDM_CHANGEDISC, CFrame::OnChangeDisc)
+EVT_MENU(IDM_RESTART, CFrame::OnRestart)
 EVT_MENU(IDM_MENU_INSTALLWAD, CFrame::OnInstallWAD)
 EVT_MENU(IDM_LIST_INSTALLWAD, CFrame::OnInstallWAD)
 EVT_MENU(IDM_LOAD_WII_MENU, CFrame::OnLoadWiiMenu)
@@ -408,6 +409,18 @@ bool CFrame::RendererIsFullscreen()
 
 void CFrame::OnQuit(wxCommandEvent& WXUNUSED (event))
 {
+	Close(true);
+}
+
+void CFrame::OnRestart(wxCommandEvent& WXUNUSED (event))
+{
+	if (Core::GetState() != Core::CORE_UNINITIALIZED)
+	{
+		wxMessageBox(wxT("You must stop the emulation before restarting."), wxT("Notice"), wxOK, this);
+		return;
+	}
+	// Get exe name and restart
+	wxExecute(wxString::Format("%s %s", wxTheApp->argv[0], UseDebugger ? "" : "-d"));
 	Close(true);
 }
 

--- a/Source/Core/DolphinWX/Src/Frame.h
+++ b/Source/Core/DolphinWX/Src/Frame.h
@@ -266,6 +266,7 @@ private:
 
 	void OnOpen(wxCommandEvent& event); // File menu
 	void DoOpen(bool Boot);
+	void OnRestart(wxCommandEvent& event);
 	void OnRefresh(wxCommandEvent& event);
 	void OnBrowse(wxCommandEvent& event);
 	void OnBootDrive(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Src/FrameTools.cpp
+++ b/Source/Core/DolphinWX/Src/FrameTools.cpp
@@ -110,6 +110,8 @@ void CFrame::CreateMenu()
 	fileMenu->AppendSeparator();
 	fileMenu->Append(IDM_BROWSE, _("&Browse for ISOs..."));
 	fileMenu->AppendSeparator();
+	fileMenu->Append(IDM_RESTART, UseDebugger ? _T("Regular mode") : _T("Debugging mode"));
+	fileMenu->AppendSeparator();
 	fileMenu->Append(wxID_EXIT, _("E&xit") + wxString(wxT("\tAlt+F4")));
 	m_MenuBar->Append(fileMenu, _("&File"));
 


### PR DESCRIPTION
## Adding menu option to switch between debugging and default GUI
### Discussion

@NeoBrainX

> - 3859deb2499f : Don't like the debug switch; should prolly be moved to the View menu and/or disabled for Release builds.

The debug switch menu item is moved to the view menu

It should be in the Release build since that build is faster than DebugFast and has some functionality of the debugging GUI, f.e. code view

> - I don't agree that Release builds need a "restart in debug mode" option. I don't see any need for this option at all, but if anything …

The log states "this makes it easier to switch between debugging and regular mode" because close → start is two actions, restart is one action; easier.

> … it shouldn't be in non-developer builds.

The debugging mode has use in the release build too; additional settings, code inspection.
