### PR TITLE
Changing the iso size from file size to space used

### DIFF
--- a/Source/Core/Common/Src/FileUtil.h
+++ b/Source/Core/Common/Src/FileUtil.h
@@ -71,6 +71,9 @@ bool Exists(const std::string &filename);
 // Returns true if filename is a directory
 bool IsDirectory(const std::string &filename);
 
+// Returns true if a file is sparse or compressed
+bool IsSparse(const std::string &filename);
+
 // Returns the size of filename (64bit)
 u64 GetSize(const std::string &filename);
 

--- a/Source/Core/DolphinWX/Src/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/Src/GameListCtrl.cpp
@@ -317,7 +317,7 @@ void CGameListCtrl::Update()
 		for (int i = 0; i < (int)m_ISOFiles.size(); i++)
 		{
 			InsertItemInReportView(i);
-			if (m_ISOFiles[i]->IsCompressed())
+			if (m_ISOFiles[i]->IsCompressed() || File::IsSparse(m_ISOFiles[i]->GetFileName()))
 				SetItemTextColour(i, wxColour(0xFF0000));
 		}
 
@@ -438,7 +438,7 @@ void CGameListCtrl::InsertItemInReportView(long _Index)
 	SetItemColumnImage(_Index, COLUMN_COUNTRY, m_FlagImageIndex[rISOFile.GetCountry()]);
 
 	// File size
-	SetItem(_Index, COLUMN_SIZE, NiceSizeFormat(rISOFile.GetFileSize()), -1);
+	SetItem(_Index, COLUMN_SIZE, NiceSizeFormat(File::GetSize(rISOFile.GetFileName())), -1);
 
 	// Background color
 	SetBackgroundColor();


### PR DESCRIPTION
## Changing the iso size from file size to space used
### Sparse size

Sparse size should be shown because
- all (non-modified) ISOs are the same size (GC 1 459 978 240 B, Wii 4 699 979 776 B) but the content size vary
- the ISO padding should be sparse rather than removed (called trim in Wii Scrubber) because the latter is a more advanced modification leading to [boot failure](http://gbatemp.net/threads/scrubbed-vs-trimmed.205660/#post-2556766) on the native hardware for some ISOs in some USB loaders
- there's a command line tool to efficiently
  - sparse multiple files `wit scrub *`
  - backup `rsync -aSv --progress /cygdrive/l/rom/ /cygdrive/e/backup/rom`, move `mv`, copy `cp` with retained sparse information
### Discussion

@delroth

> I'm not sure if st_blocks unit size == 512 is a valid assumption to make, especially with 4K sectors disks.

st_blocks is 512 B for AF too

> Is there any reference to the fact that st_blocks always counts 512 bytes blocks?

The quote ["the number of blocks allocated to the file, 512-byte units"](https://www.google.com/search?q=the+number+of+blocks+allocated+to+the+file%2C+512-byte+units)

[03:16] @Sonicadvance1 JPeterson, Pull request #18, no

What's the reason that you oppose the change?
