### PR TITLE
Updating Cheats manager when the ISO is changed etc.

### DIFF
--- a/Source/Core/DolphinWX/Src/CheatsWindow.h
+++ b/Source/Core/DolphinWX/Src/CheatsWindow.h
@@ -96,6 +96,7 @@ class wxCheatsWindow : public wxDialog
 	public:
 		wxCheatsWindow(wxWindow* const parent);
 		~wxCheatsWindow();
+		void UpdateGUI();
 
 	protected:
 
@@ -105,6 +106,7 @@ class wxCheatsWindow : public wxDialog
 		};
 
 		// --- GUI Controls ---
+		wxButton* button_apply;
 		wxNotebook *m_Notebook_Main;
 
 		wxPanel *m_Tab_Cheats;
@@ -134,6 +136,7 @@ class wxCheatsWindow : public wxDialog
 		void Init_ChildControls();
 
 		void Load_ARCodes();
+		void Load_GeckoCodes();
 
 		// --- Wx Events Handlers ---
 

--- a/Source/Core/DolphinWX/Src/FrameTools.cpp
+++ b/Source/Core/DolphinWX/Src/FrameTools.cpp
@@ -1133,6 +1133,7 @@ void CFrame::OnConfigMain(wxCommandEvent& WXUNUSED (event))
 	CConfigMain ConfigMain(this);
 	if (ConfigMain.ShowModal() == wxID_OK)
 		m_GameListCtrl->Update();
+	UpdateGUI();
 }
 
 void CFrame::OnConfigGFX(wxCommandEvent& WXUNUSED (event))
@@ -1568,6 +1569,9 @@ void CFrame::UpdateGUI()
 	if (DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU).IsValid())
 		GetMenuBar()->FindItem(IDM_LOAD_WII_MENU)->Enable(!Initialized);
 
+	// Tools
+	GetMenuBar()->FindItem(IDM_CHEATS)->Enable(SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats);
+
 	GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE1)->Enable(RunningWii);
 	GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE2)->Enable(RunningWii);
 	GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE3)->Enable(RunningWii);
@@ -1675,6 +1679,15 @@ void CFrame::UpdateGUI()
 
 	// Commit changes to manager
 	m_Mgr->Update();
+
+	// Update non-modal windows
+	if (g_CheatsWindow)
+	{
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats)
+			g_CheatsWindow->UpdateGUI();
+		else
+			g_CheatsWindow->Close();
+	}
 }
 
 void CFrame::UpdateGameList()

--- a/Source/Core/DolphinWX/Src/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/Src/GeckoCodeDiag.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "GeckoCodeDiag.h"
+#include "Core.h"
 #include "WxUtils.h"
 
 #include <SFML/Network/Http.hpp>
@@ -59,10 +60,10 @@ CodeConfigPanel::CodeConfigPanel(wxWindow* const parent)
 	SetSizerAndFit(sizer_main);
 }
 
-void CodeConfigPanel::UpdateCodeList()
+void CodeConfigPanel::UpdateCodeList(bool checkRunning)
 {
 	// disable the button if it doesn't have an effect
-	btn_download->Enable(!m_gameid.empty());
+	btn_download->Enable((!checkRunning || Core::IsRunning()) && !m_gameid.empty());
 
 	m_listbox_gcodes->Clear();
 	// add the codes to the listbox
@@ -80,14 +81,15 @@ void CodeConfigPanel::UpdateCodeList()
 	UpdateInfoBox(evt);
 }
 
-void CodeConfigPanel::LoadCodes(const IniFile& inifile, const std::string& gameid)
+void CodeConfigPanel::LoadCodes(const IniFile& inifile, const std::string& gameid, bool checkRunning)
 {
 	m_gameid = gameid;
 
 	m_gcodes.clear();
-	Gecko::LoadCodes(inifile, m_gcodes);
+	if (!checkRunning || Core::IsRunning())
+		Gecko::LoadCodes(inifile, m_gcodes);
 
-	UpdateCodeList();
+	UpdateCodeList(checkRunning);
 }
 
 void CodeConfigPanel::ToggleCode(wxCommandEvent& evt)

--- a/Source/Core/DolphinWX/Src/GeckoCodeDiag.h
+++ b/Source/Core/DolphinWX/Src/GeckoCodeDiag.h
@@ -20,7 +20,7 @@ public:
 	CodeConfigPanel(wxWindow* const parent);
 
 
-	void LoadCodes(const IniFile& inifile, const std::string& gameid = "");
+	void LoadCodes(const IniFile& inifile, const std::string& gameid = "", bool checkRunning = false);
 	const std::vector<GeckoCode>& GetCodes() const { return m_gcodes; }
 
 protected:
@@ -29,7 +29,7 @@ protected:
 	void DownloadCodes(wxCommandEvent&);
 	//void ApplyChanges(wxCommandEvent&);
 
-	void UpdateCodeList();
+	void UpdateCodeList(bool checkRunning = false);
 
 private:
 	std::vector<GeckoCode> m_gcodes;


### PR DESCRIPTION
## Updating Cheats manager when the ISO is changed etc.
### Non-modal dialogs

The Cheats manager dialog was made non-modal in 983d5d1f

The benefit with a non-modal dialog is the option to keep it open during emulation without
- blocking the main window
- disabling the hotkeys because the modal dialog receive keyboard input instead of the main window

Non-modal dialogs should be updated when the ISO is changed because that allow it to show information for the current ISO
### Cheats disabled

When "Config → General → Enable Cheats" is disabled
- the "Tools → Cheats Manager" menu option is disabled
- the Cheats Manager window is closed

because
- the cheats have no use during a running emulation in this case
- it'll otherwise show an empty "AR Codes" tab which incorrectly indicate that the ISO doesn't have AR codes

However because the dialog has a use for enabling/disabling cheats it could be useful to allow the dialog with "Config → General → Enable Cheats" disabled, this isn't done because
- it would require changes in "namespace ActionReplay" to load the codes when "Config → General → Enable Cheats" is disabled too
