### PR TITLE
Adding revision reader to Wii ISOs

### DIFF
--- a/Source/Core/DiscIO/Src/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/Src/VolumeWiiCrypted.cpp
@@ -156,6 +156,18 @@ std::string CVolumeWiiCrypted::GetMakerID() const
 	return makerID;
 }
 
+int CVolumeWiiCrypted::GetRevision() const
+{
+	if (!m_pReader)
+		return 0;
+
+	u8 Revision;
+	if (!RAWRead(7, 1, &Revision))
+		return 0;
+
+	return Revision;
+}
+
 std::vector<std::string> CVolumeWiiCrypted::GetNames() const
 {
 	std::vector<std::string> names;

--- a/Source/Core/DiscIO/Src/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/Src/VolumeWiiCrypted.h
@@ -24,6 +24,7 @@ public:
 	void GetTMD(u8* _pBuffer, u32* _sz) const;
 	std::string GetUniqueID() const;
 	std::string GetMakerID() const;
+	int GetRevision() const;
 	std::vector<std::string> GetNames() const;
 	u32 GetFSTSize() const;
 	std::string GetApploaderDate() const;


### PR DESCRIPTION
## Adding revision reader to Wii ISOs
### Problem

https://github.com/mirror/dolphin-emu/pull/24 require version information
### Discussion

> [03:14] @Sonicadvance1 JPeterson, Pull request #21, We don't care, no.
> 
> [03:27] @Matt_P Sonicadvance1: what is wrong with having a revisiion get method in CVolumeWiiCrypted
> [03:27] @Matt_P to me that is fine, what he does with it may or may not be though
> [03:27] @Sonicadvance1 Matt_P, What's the reason for?
> [03:28] @Sonicadvance1 A revision method is easy sure, but with no clear reason for it. I don't understand why it is needed
> [03:28] @Matt_P Well we could have the revisiion listed in game properties
