### PR TITLE
Changing the Gecko code comparison from metadata to data comparison

### DIFF
--- a/Source/Core/Core/Src/GeckoCode.cpp
+++ b/Source/Core/Core/Src/GeckoCode.cpp
@@ -63,6 +63,38 @@ u32 GeckoCode::Code::GetAddress() const
 	return gcaddress + (use_po ? pointer_address : (base_address & 0xFE000000));
 }
 
+// return true if a code exists
+bool GeckoCode::Exist(u32 address, u32 data)
+{
+	std::vector<GeckoCode::Code>::const_iterator
+		codes_iter = codes.begin(),
+		codes_end = codes.end();
+	for (; codes_iter != codes_end; ++codes_iter)
+	{
+		if (codes_iter->address == address && codes_iter->data == data)
+			return true;
+	}
+	return false;
+}
+
+// return true if the code is identical
+bool GeckoCode::Compare(GeckoCode compare) const
+{
+	if (codes.size() != compare.codes.size())
+		return false;
+
+	int exist = 0;
+	std::vector<GeckoCode::Code>::const_iterator
+		codes_iter = codes.begin(),
+		codes_end = codes.end();
+	for (; codes_iter != codes_end; ++codes_iter)
+	{
+		if (compare.Exist(codes_iter->address, codes_iter->data))
+			exist++;
+	}
+	return exist == codes.size();
+}
+
 static std::mutex active_codes_lock;
 
 // currently running code

--- a/Source/Core/Core/Src/GeckoCode.h
+++ b/Source/Core/Core/Src/GeckoCode.h
@@ -66,6 +66,9 @@ namespace Gecko
 		std::vector<std::string>	notes;
 
 		bool	enabled;
+
+		bool Compare(GeckoCode compare) const;
+		bool Exist(u32 address, u32 data);
 	};
 
 	void SetActiveCodes(const std::vector<GeckoCode>& gcodes);

--- a/Source/Core/DolphinWX/Src/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/Src/GeckoCodeDiag.cpp
@@ -283,9 +283,8 @@ void CodeConfigPanel::DownloadCodes(wxCommandEvent&)
 						break;
 					}
 
-					// code with this name+creator exists
-					if (existing_gcodes_iter->name == gcodes_iter->name &&
-						existing_gcodes_iter->creator == gcodes_iter->creator)
+					// code exists
+					if (existing_gcodes_iter->Compare(*gcodes_iter))
 						break;
 				}
 			}


### PR DESCRIPTION
## Changing the Gecko code comparison from metadata to data comparison
### Problem

http://geckocodes.org/txt.php?txt=SF8E01 return many codes with the same metadata because it contain codes for more than one program version
### Solution

Compare the code instead of the metadata because that'll add all unique codes
