### PR TITLE
Considering version for Gecko codes

### DIFF
--- a/Source/Core/Core/Src/ActionReplay.cpp
+++ b/Source/Core/Core/Src/ActionReplay.cpp
@@ -111,7 +111,7 @@ bool CompareValues(const u32 val1, const u32 val2, const int type);
 
 // ----------------------
 // AR Remote Functions
-void LoadCodes(IniFile &ini, bool forceLoad)
+void LoadCodes(IniFile &ini, u8 version, bool forceLoad)
 {
 	// Parses the Action Replay section of a game ini file.
 	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats 
@@ -123,8 +123,9 @@ void LoadCodes(IniFile &ini, bool forceLoad)
 	ARCode currentCode;
 	arCodes.clear();
 
-	if (!ini.GetLines("ActionReplay", lines))
-		return;  // no codes found.
+	if (!ini.GetLines(StringFromFormat("ActionReplay%02x", version).c_str(), lines))
+		if (!ini.GetLines("ActionReplay", lines))
+			return;  // no codes found.
 
 	std::vector<std::string>::const_iterator
 		it = lines.begin(),
@@ -217,9 +218,9 @@ void LoadCodes(IniFile &ini, bool forceLoad)
 	UpdateActiveList();
 }
 
-void LoadCodes(std::vector<ARCode> &_arCodes, IniFile &ini)
+void LoadCodes(std::vector<ARCode> &_arCodes, IniFile &ini, u8 version)
 {
-	LoadCodes(ini, true);
+	LoadCodes(ini, version, true);
 	_arCodes = arCodes;
 }
 

--- a/Source/Core/Core/Src/ActionReplay.h
+++ b/Source/Core/Core/Src/ActionReplay.h
@@ -27,8 +27,8 @@ struct ARCode
 
 void RunAllActive();
 bool RunCode(const ARCode &arcode);
-void LoadCodes(IniFile &ini, bool forceLoad);
-void LoadCodes(std::vector<ARCode> &_arCodes, IniFile &ini);
+void LoadCodes(IniFile &ini, u8 version, bool forceLoad);
+void LoadCodes(std::vector<ARCode> &_arCodes, IniFile &ini, u8 version);
 size_t GetCodeListSize();
 ARCode GetARCode(size_t index);
 void SetARCode_IsActive(bool active, size_t index);

--- a/Source/Core/Core/Src/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Src/Boot/Boot_BS2Emu.cpp
@@ -149,7 +149,8 @@ bool CBoot::EmulatedBS2_GC()
 
 	// Load patches
 	std::string gameID = VolumeHandler::GetVolume()->GetUniqueID();
-	PatchEngine::LoadPatches(gameID.c_str());
+	u8 version = VolumeHandler::GetVolume()->GetRevision();
+	PatchEngine::LoadPatches(gameID.c_str(), version);
 	
 	PowerPC::ppcState.DebugCount = 0;
 
@@ -380,7 +381,8 @@ bool CBoot::EmulatedBS2_Wii()
 
 		// Load patches and run startup patches
 		std::string gameID = VolumeHandler::GetVolume()->GetUniqueID();
-		PatchEngine::LoadPatches(gameID.c_str());
+		u8 version = VolumeHandler::GetVolume()->GetRevision();
+		PatchEngine::LoadPatches(gameID.c_str(), version);
 
 		// return
 		PC = PowerPC::ppcState.gpr[3];

--- a/Source/Core/Core/Src/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Src/Boot/Boot_WiiWAD.cpp
@@ -106,7 +106,7 @@ bool CBoot::Boot_WiiWAD(const char* _pFilename)
 	// Load patches and run startup patches
 	const DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(_pFilename);
 	if (pVolume != NULL)
-		PatchEngine::LoadPatches(pVolume->GetUniqueID().c_str());
+		PatchEngine::LoadPatches(pVolume->GetUniqueID().c_str(), pVolume->GetRevision());
 
 	return true;
 }

--- a/Source/Core/Core/Src/PatchEngine.cpp
+++ b/Source/Core/Core/Src/PatchEngine.cpp
@@ -148,7 +148,7 @@ int GetSpeedhackCycles(const u32 addr)
 		return iter->second;
 }
 
-void LoadPatches(const char *gameID)
+void LoadPatches(const char *gameID, u8 version)
 {
 	IniFile ini;
 	std::string filename = File::GetUserPath(D_GAMECONFIG_IDX) + gameID + ".ini";
@@ -156,7 +156,7 @@ void LoadPatches(const char *gameID)
 	if (ini.Load(filename.c_str()))
 	{
 		LoadPatchSection("OnFrame", onFrame, ini);
-		ActionReplay::LoadCodes(ini, false);
+		ActionReplay::LoadCodes(ini, version, false);
 		
 		// lil silly
 		std::vector<Gecko::GeckoCode> gcodes;

--- a/Source/Core/Core/Src/PatchEngine.h
+++ b/Source/Core/Core/Src/PatchEngine.h
@@ -37,7 +37,7 @@ struct Patch
 
 int GetSpeedhackCycles(const u32 addr);
 void LoadPatchSection(const char *section, std::vector<Patch> &patches, IniFile &ini);
-void LoadPatches(const char *gameID);
+void LoadPatches(const char *gameID, u8 version);
 void ApplyFramePatches();
 void ApplyARPatches();
 

--- a/Source/Core/DolphinWX/Src/ISOProperties.h
+++ b/Source/Core/DolphinWX/Src/ISOProperties.h
@@ -33,6 +33,14 @@ struct PHackData
 	std::string PHZFar;
 };
 
+struct ISO
+{
+	std::string id;
+	u8 version;
+	std::string name;
+	DiscIO::IVolume::ECountry country;
+};
+
 class CISOProperties : public wxDialog
 {
 public:
@@ -195,6 +203,7 @@ private:
 
 	IniFile GameIni;
 	std::string GameIniFile;
+	ISO m_ISO;
 
 	void LoadGameConfig();
 	void PatchList_Load();


### PR DESCRIPTION
## Considering version for Gecko codes
### Problem

"Cheats Manager → Gecko Codes" display the codes for all versions, f.e for SF8E01

```
$infinite health [wiiztec]
0480BD8C 00000002

$infinite health [wiiztec]
0480DD8C 00000002
```

This is a problem because
- it's possible to select a code for the wrong version
- the code for the wrong version use space in the list which result in more scrolling

Binary patches should consider the version because the memory location is different between versions
### Solution

The patches should be version aware by having the 0x007 version in the
- ini setting category name f.e. "ActionReplay00"
- filename f.e. GALE0100.ini

F.e. [these](https://github.com/mirror/dolphin-emu/blob/master/Data/User/GameConfig/GALE01.ini) AR codes are for version 0x00
## Versions

There are

three [GALE01](http://www.gametdb.com/Wii/GALE01) versions

two [SF8E01](http://www.gametdb.com/Wii/SF8E01) versions

```
version     apploader date  data at 0x00
0           ?               SF8E01 0x0000
1           2009-12-11      SF8E01 0x0001
```
