### PR TITLE
Adding AR code repeat limit

### DIFF
--- a/Source/Core/Core/Src/ActionReplay.cpp
+++ b/Source/Core/Core/Src/ActionReplay.cpp
@@ -34,6 +34,9 @@
 namespace ActionReplay
 {
 
+// avoid incorrect codes
+const u8 REPEAT_LIMIT = 0xffff;
+
 enum
 {
 	// Zero Code Types
@@ -500,7 +503,8 @@ bool Subtype_RamWriteAndFill(const ARAddr addr, const u32 data)
 		LogInfo("8-bit Write");
 		LogInfo("--------");
 		u32 repeat = data >> 8;
-		for (u32 i = 0; i <= repeat; ++i)
+		LogInfo("Repeat: %08x", repeat);
+		for (u32 i = 0; i <= repeat && repeat <= REPEAT_LIMIT; ++i)
 		{
 			Memory::Write_U8(data & 0xFF, new_addr + i);
 			LogInfo("Wrote %08x to address %08x", data & 0xFF, new_addr + i);
@@ -514,7 +518,8 @@ bool Subtype_RamWriteAndFill(const ARAddr addr, const u32 data)
 		LogInfo("16-bit Write");
 		LogInfo("--------");
 		u32 repeat = data >> 16;
-		for (u32 i = 0; i <= repeat; ++i)
+		LogInfo("Repeat: %08x", repeat);
+		for (u32 i = 0; i <= repeat && repeat <= REPEAT_LIMIT; ++i)
 		{
 			Memory::Write_U16(data & 0xFFFF, new_addr + i * 2);
 			LogInfo("Wrote %08x to address %08x", data & 0xFFFF, new_addr + i * 2);


### PR DESCRIPTION
## Adding AR code repeat limit
### Problem

An incorrect code will overwrite much memory and crash the process

F.e. this [GALE01](https://github.com/mirror/dolphin-emu/blob/e5319700523c0639e7a88d7c5ebf6f23f407a3b2/Data/User/GameConfig/GALE01.ini) code

```
17:52:053 Src\ActionReplay.cpp:241 I[ActionReplay]: Code Name: P1 - Invincible
17:52:054 Src\ActionReplay.cpp:241 I[ActionReplay]: Number of codes: 3
17:52:054 Src\ActionReplay.cpp:241 I[ActionReplay]: --- Running Code: 00084e6c 08000000 ---
17:52:055 Src\ActionReplay.cpp:241 I[ActionReplay]: Doing Normal Code 00000000
17:52:055 Src\ActionReplay.cpp:241 I[ActionReplay]: Subtype: 00000000
17:52:056 Src\ActionReplay.cpp:241 I[ActionReplay]: Doing Ram Write And Fill
17:52:056 Src\ActionReplay.cpp:241 I[ActionReplay]: Hardware Address: 80084e6c
17:52:056 Src\ActionReplay.cpp:241 I[ActionReplay]: Size: 00000000
17:52:057 Src\ActionReplay.cpp:241 I[ActionReplay]: 8-bit Write
17:52:057 Src\ActionReplay.cpp:241 I[ActionReplay]: --------
17:52:057 Src\ActionReplay.cpp:241 I[ActionReplay]: Repeat: 00080000
17:52:057 Src\ActionReplay.cpp:241 I[ActionReplay]: --------
```
### Solution

Limit repeat to 0xffff because
- there's no correct code that has a higher repeat than that
### Discussion

> [03:13] @Sonicadvance1 JPeterson, Pull request #25, no

What's the reason that you oppose the change?

> [03:32] @Sonicadvance1 JPeterson, Pull request #25, It's an artificial limitation. If someone has the wrong code in the database, an issue should instead be created to have that particular code rectified or removed
