### PR TITLE
Adding MMU state values to state

### DIFF
--- a/Source/Core/Core/Src/HW/MemmapFunctions.cpp
+++ b/Source/Core/Core/Src/HW/MemmapFunctions.cpp
@@ -598,9 +598,6 @@ union UPTE2
 	u32 Hex;
 };
 
-u32 pagetable_base = 0;
-u32 pagetable_hashmask = 0;
-
 void GenerateDSIException(u32 _EffectiveAddress, bool _bWrite)
 {
 	if (_bWrite)
@@ -644,8 +641,8 @@ void SDRUpdated()
 	{
 		return;
 	}
-	pagetable_base = htaborg<<16;
-	pagetable_hashmask = ((xx<<10)|0x3ff);
+	PowerPC::ppcState.pagetable_base = htaborg<<16;
+	PowerPC::ppcState.pagetable_hashmask = ((xx<<10)|0x3ff);
 } 
 
 
@@ -821,7 +818,7 @@ u32 TranslatePageAddress(const u32 _Address, const XCheckTLBFlag _Flag)
 
 	// hash function no 1 "xor" .360
 	u32 hash1 = (VSID ^ page_index);
-	u32 pteg_addr = ((hash1 & pagetable_hashmask) << 6) | pagetable_base;
+	u32 pteg_addr = ((hash1 & PowerPC::ppcState.pagetable_hashmask) << 6) | PowerPC::ppcState.pagetable_base;
 
 	// hash1
 	for (int i = 0; i < 8; i++)
@@ -856,7 +853,7 @@ u32 TranslatePageAddress(const u32 _Address, const XCheckTLBFlag _Flag)
 
 	// hash function no 2 "not" .360
 	hash1 = ~hash1;
-	pteg_addr = ((hash1 & pagetable_hashmask) << 6) | pagetable_base;
+	pteg_addr = ((hash1 & PowerPC::ppcState.pagetable_hashmask) << 6) | PowerPC::ppcState.pagetable_base;
 	for (int i = 0; i < 8; i++) 
 	{
 		u32 pte = bswap(*(u32*)&pRAM[pteg_addr]);

--- a/Source/Core/Core/Src/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/Src/PowerPC/PowerPC.cpp
@@ -138,6 +138,8 @@ void Init(int cpu_core)
 	ppcState.itlb_last = 0;
 	memset(ppcState.itlb_va, 0, sizeof(ppcState.itlb_va));
 	memset(ppcState.itlb_pa, 0, sizeof(ppcState.itlb_pa));
+	ppcState.pagetable_base = 0;
+	ppcState.pagetable_hashmask = 0;
 
 	ResetRegisters();
 	PPCTables::InitTables(cpu_core);

--- a/Source/Core/Core/Src/PowerPC/PowerPC.h
+++ b/Source/Core/Core/Src/PowerPC/PowerPC.h
@@ -64,6 +64,9 @@ struct GC_ALIGNED64(PowerPCState)
 	u32 itlb_va[128];
 	u32 itlb_pa[128];
 
+	u32 pagetable_base;
+	u32 pagetable_hashmask;
+
 	InstructionCache iCache;
 };
 

--- a/Source/Core/Core/Src/State.cpp
+++ b/Source/Core/Core/Src/State.cpp
@@ -59,7 +59,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 18;
+static const u32 STATE_VERSION = 19;
 
 enum
 {


### PR DESCRIPTION
## Adding MMU state values to state
### Problem

State loading before CCPU::Run() in
- F-Zero and Rouge Leader and potentially other programs that use the options TLBHack or MMU

result in a [DSI interrupt](http://hitmen.c02.at/files/yagcd/yagcd/chap6.html#sec6.1.3) because these values start at 0 which is the wrong value
### Solution

Save the MMU state values
### Discussion

The problem hasn't been fixed before because it's not noticed when loading a state 
- during a running emulation if the values for the current state is correct which they often are because the values are set at boot and not changed after that
- after a terminated emulation (that doesn't reset the values) for the same ISO the state is for and the last values are right

These values are used for page trable translation discussed at [Terms and Acronyms](http://hitmen.c02.at/files/yagcd/yagcd/chap18.html#sec18.7)

> MMU PPC Memory Management Unit. Translates virtual address to physical. MMU has two translation mechanisms: block address translation and page table translation
## Shutdown
### Problem

It's not clear which values are state values
### Solution

Adding the values to shutdown because that makes it clear that they're part of the system state
## Fake VMEM
### Problem

A state saved with "TLBHack" doesn't work if it's changed to "MMU" because fake VMEM isn't saved if "TLBHack" isn't used because
- it's 32 MB which makes the state larger without benefit when its not used
### Solution

Fake VMEM should be saved regardless of the TLBHack setting because
- the state can be loaded with "MMU" (instead of "TLBHack") because fake VMEM is ignored and unnecessary
- its size is only 152 KB (,005 larger than the compressed size 27 MB) when it's empty because the state is compressed

<!-- -->

```
truncate -s 32M file.bin
lzop -fo file.lzo file.bin
du -h file.lzo
152K   file.lzo
```
