### PR TITLE
Removing ISO ini presence requirement for reading movie settings

### DIFF
--- a/Source/Core/Core/Src/BootManager.cpp
+++ b/Source/Core/Core/Src/BootManager.cpp
@@ -108,20 +108,6 @@ bool BootCore(const std::string& _rFilename)
 		game_ini.Get("Core", "HLE_BS2",				&StartUp.bHLE_BS2, StartUp.bHLE_BS2);
 		VideoBackend::ActivateBackend(StartUp.m_strVideoBackend);
 
-		if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
-		{
-			StartUp.bCPUThread = Movie::IsDualCore();
-			StartUp.bSkipIdle = Movie::IsSkipIdle();
-			StartUp.bDSPHLE = Movie::IsDSPHLE();
-			StartUp.bProgressive = Movie::IsProgressive();
-			StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
-			StartUp.iCPUCore = Movie::GetCPUMode();
-			if (Movie::IsUsingMemcard() && Movie::IsStartingFromClearSave() && !StartUp.bWii)
-			{
-				if (File::Exists("Movie.raw"))
-					File::Delete("Movie.raw");
-			}
-		}
 		// Wii settings
 		if (StartUp.bWii)
 		{
@@ -129,6 +115,22 @@ bool BootCore(const std::string& _rFilename)
 			SConfig::GetInstance().m_SYSCONF->Save();
 		}
 	} 
+
+	// movie settings
+	if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
+	{
+		StartUp.bCPUThread = Movie::IsDualCore();
+		StartUp.bSkipIdle = Movie::IsSkipIdle();
+		StartUp.bDSPHLE = Movie::IsDSPHLE();
+		StartUp.bProgressive = Movie::IsProgressive();
+		StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
+		StartUp.iCPUCore = Movie::GetCPUMode();
+		if (Movie::IsUsingMemcard() && Movie::IsStartingFromClearSave() && !StartUp.bWii)
+		{
+			if (File::Exists("Movie.raw"))
+				File::Delete("Movie.raw");
+		}
+	}
 
 	// Run the game
 	// Init the core


### PR DESCRIPTION
## Removing ISO ini presence requirement for reading movie settings
### Problem

The movie settings aren't loaded when running Dolphin with [minimum settings](https://github.com/mirror/dolphin-emu/issues/26) because the settings aren't read if there's no ISO ini
### Solution

Remove the iso ini presence requirement for reading movie settings
