### PR TITLE
Adding DSP state values to state

### DIFF
--- a/Source/Core/Core/Src/DSP/DSPCore.cpp
+++ b/Source/Core/Core/Src/DSP/DSPCore.cpp
@@ -137,6 +137,7 @@ bool DSPCore_Init(const char *irom_filename, const char *coef_filename,
 {
 	g_dsp.step_counter = 0;
 	cyclesLeft = 0;
+	init_hax = false;
 	dspjit = NULL;
 	
 	g_dsp.irom = (u16*)AllocateMemoryPages(DSP_IROM_BYTE_SIZE);

--- a/Source/Core/Core/Src/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/Src/DSP/DSPHWInterface.cpp
@@ -246,14 +246,9 @@ static void gdsp_idma_in(u16 dsp_addr, u32 addr, u32 size)
 	}
 	WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
 
-	g_dsp.iram_crc = DSPHost_CodeLoaded(g_dsp.cpu_ram + (addr & 0x0fffffff), size);
-	
-	NOTICE_LOG(DSPLLE, "*** Copy new UCode from 0x%08x to 0x%04x (crc: %8x)", addr, dsp_addr, g_dsp.iram_crc);
+	DSPHost_CodeLoaded((const u8*)g_dsp.iram + dsp_addr, size);
 
-	if (dspjit)
-		dspjit->ClearIRAM();
-	
-	DSPAnalyzer::Analyze();
+	NOTICE_LOG(DSPLLE, "*** Copy new UCode from 0x%08x to 0x%04x (crc: %8x)", addr, dsp_addr, g_dsp.iram_crc);
 }
 
 static void gdsp_idma_out(u16 dsp_addr, u32 addr, u32 size)

--- a/Source/Core/Core/Src/DSP/DSPHost.h
+++ b/Source/Core/Core/Src/DSP/DSPHost.h
@@ -15,7 +15,7 @@ void DSPHost_WriteHostMemory(u8 value, u32 addr);
 bool DSPHost_OnThread();
 bool DSPHost_Wii();
 void DSPHost_InterruptRequest();
-u32 DSPHost_CodeLoaded(const u8 *ptr, int size);
+void DSPHost_CodeLoaded(const u8 *ptr, int size);
 void DSPHost_UpdateDebugger();
 
 #endif

--- a/Source/Core/Core/Src/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/Src/HW/DSPLLE/DSPLLE.cpp
@@ -16,6 +16,7 @@
 #include "Core.h"
 
 #include "DSPLLEGlobals.h" // Local
+#include "DSP/DSPHost.h"
 #include "DSP/DSPInterpreter.h"
 #include "DSP/DSPHWInterface.h"
 #include "DSP/disassemble.h"
@@ -67,7 +68,6 @@ void DSPLLE::DoState(PointerWrap &p)
 		p.Do(g_dsp.reg_stack[i]);
 	}
 
-	p.Do(g_dsp.iram_crc);
 	p.Do(g_dsp.step_counter);
 	p.Do(g_dsp.ifx_regs);
 	p.Do(g_dsp.mbox[0]);
@@ -75,8 +75,11 @@ void DSPLLE::DoState(PointerWrap &p)
 	UnWriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
 	p.DoArray(g_dsp.iram, DSP_IRAM_SIZE);
 	WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
+	if (p.GetMode() == PointerWrap::MODE_READ)
+		DSPHost_CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
 	p.DoArray(g_dsp.dram, DSP_DRAM_SIZE);
 	p.Do(cyclesLeft);
+	p.Do(init_hax);
 	p.Do(m_cycle_count);
 
 	bool prevInitMixer = m_InitMixer;

--- a/Source/Core/Core/Src/State.cpp
+++ b/Source/Core/Core/Src/State.cpp
@@ -59,7 +59,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 17;
+static const u32 STATE_VERSION = 18;
 
 enum
 {


### PR DESCRIPTION
# Adding DSP state values to state
## DSPAnalyzer::code_flags
### Problem

State loading

before CCPU::Run()

i.o.w. before execution with f.e. `./dolphin -B -e twist_road_intro.dtm`

in

Crazy Taxi or another program when using "DSPHLE = False" run to

```
ERROR_LOG(DSPLLE, "%04x DSP ERROR: Read from UNKNOWN (%04x) memory", g_dsp.pc, addr);
ERROR_LOG(DSPLLE, "%04x DSP ERROR: Write to UNKNOWN (%04x) memory", g_dsp.pc, addr);
ERROR_LOG(DSPLLE, "%04x DSP ERROR: Executing from invalid (%04x) memory", g_dsp.pc, addr);
ERROR_LOG(DSPLLE, "%04x MW %04x (%04x)", g_dsp.pc, addr, val);
ERROR_LOG(DSPLLE, "%04x MW %04x (%04x)", g_dsp.pc, addr, val);
ERROR_LOG(DSPLLE, "%04x MR %04x (%04x)", g_dsp.pc, addr, g_dsp.ifx_regs[addr & 0xFF]);
ERROR_LOG(DSPLLE, "%04x MR %04x (%04x)", g_dsp.pc, addr, g_dsp.ifx_regs[addr & 0xFF]);
```

after f.e. 507 DSP instructions (in the code I tested in Crazy Taxi)

because `DSPAnalyzer::code_flags` isn't written (is left at 0) when a state is loaded
### Solution

Write DSPAnalyzer::code_flags when a state is loaded
### Discussion

The problem hasn't been fixed before because it's not noticed when loading a state 
- during a running emulation if the values for the current state is correct which they often are because the values are set at boot and not changed after that

Another result of the problem is that the DSP LLE "Disasm" tab isn't updated with the DSP code
### Alternative solutions

DSPAnalyzer::code_flag is calculated rather than saved because
- calculatable values shouldn't be saved
- f.e. recompiled code isn't saved because it's calculatable
## init_hax

The value `init_hax` is saved because it's a state value

It's reset in `DSPCore_Init` because
- it's a state value that should be reset on init or shutdown
- presence in init or shutdown makes it easier to determine which values are state values
## g_dsp.iram_crc

Isn't saved because
- it can be calculated
- calculatable values shouldn't be saved
