### PR TITLE
Removing newline EOF requirement from ini

### DIFF
--- a/Source/Core/Common/Src/IniFile.cpp
+++ b/Source/Core/Common/Src/IniFile.cpp
@@ -408,8 +408,6 @@ bool IniFile::Load(const char* filename)
 		}
 #endif
 
-		if (in.eof()) break;
-
 		if (line.size() > 0)
 		{
 			if (line[0] == '[')


### PR DESCRIPTION
## Removing newline EOF requirement from ini

because it doesn't have meaning
### Discussion

> [03:25] @Sonicadvance1 JPeterson, Pull request #32, yes
