### PR TITLE
Equalising the 32 and 64 bit state compression

### DIFF
--- a/Source/Core/Core/Src/State.cpp
+++ b/Source/Core/Core/Src/State.cpp
@@ -59,7 +59,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 19;
+static const u32 STATE_VERSION = 20;
 
 enum
 {
@@ -257,7 +257,7 @@ void CompressAndDumpState(CompressAndDumpState_args save_args)
 		lzo_uint i = 0;
 		while (true)
 		{
-			lzo_uint cur_len = 0;
+			lzo_uint32 cur_len = 0;
 			lzo_uint out_len = 0;
 
 			if ((i + IN_LEN) >= buffer_size)
@@ -269,7 +269,7 @@ void CompressAndDumpState(CompressAndDumpState_args save_args)
 				PanicAlertT("Internal LZO Error - compression failed");
 
 			// The size of the data to write is 'out_len'
-			f.WriteArray(&out_len, 1);
+			f.WriteArray((lzo_uint32*)&out_len, 1);
 			f.WriteBytes(out, out_len);
 
 			if (cur_len != IN_LEN)
@@ -379,7 +379,7 @@ void LoadFileStateData(const std::string& filename, std::vector<u8>& ret_data)
 		lzo_uint i = 0;
 		while (true)
 		{
-			lzo_uint cur_len = 0;  // number of bytes to read
+			lzo_uint32 cur_len = 0;  // number of bytes to read
 			lzo_uint new_len = 0;  // number of bytes to write
 
 			if (!f.ReadArray(&cur_len, 1))


### PR DESCRIPTION
## Equalising the 32 and 64 bit state compression
### Problem

The LZO block size value bit length is different in 32 and 64 bit with the result that a 64 bit state can't be loaded in a 32 bit build and vice versa

Compressing this file

```
printf test>file.bin
```

with the current code write this when compressed with `lzo_uint src_len` 

```
$ xxd 64.lzo
0000000: 0000 0000 0000 0004 7465 7374 0000 0000  ........test....
```

and this when compressed with `lzo_uint32 src_len`

```
$ xxd 32.lzo
0000000: 0000 0004 7465 7374 0000 0000            ....test....
```
### Solution

Writing the block size with 32 bits in a 64 bit build too because that
- make the state equal for both 32 and 64 bit builds
- allow loading the state from both

This mirror the `lzop` code for [`lzo1x_1_compress`](https://github.com/mirror/lzop/blob/master/src/p_lzo.c#L322) and [`lzo1x_decompress`](https://github.com/mirror/lzop/blob/master/src/p_lzo.c#L538)

The block length doesn't exceed a 32 bit value because of these limits
- [lzop](https://github.com/mirror/lzop/blob/master/src/lzop.c#L429): 0x80000000
- [dolphin-emu](https://github.com/mirror/dolphin-emu/blob/master/Source/Core/Core/Src/State.cpp#L34): 0x80
### Discussion

> [06:48] <_RachelB> JPeterson: oh, if you're going to do anything with the compression, something to keep in mind is that states created in 64 bit builds cannot be extracted in 32 bit builds, and vice versa. Uncompressed save states work perfectly. That might be worth fixing if you're making changes anyway

This is solved in this patch

> [09:13] <_RachelB> JPeterson: oh great. go ahead and merge it

I'll merge it in one day if it's not opposed because
- that give time for consideration
