### PR TITLE
Added functionality to memory and code view

### DIFF
--- a/Source/Core/DolphinWX/Src/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Src/Debugger/CodeView.cpp
@@ -40,8 +40,11 @@ BEGIN_EVENT_TABLE(CCodeView, wxControl)
 	EVT_LEFT_DOWN(CCodeView::OnMouseDown)
 	EVT_LEFT_UP(CCodeView::OnMouseUpL)
 	EVT_MOTION(CCodeView::OnMouseMove)
+	EVT_MOUSEWHEEL(CCodeView::OnMouseScroll)
 	EVT_RIGHT_DOWN(CCodeView::OnMouseDown)
 	EVT_RIGHT_UP(CCodeView::OnMouseUpR)
+	EVT_MIDDLE_DOWN(CCodeView::OnMouseDownM)
+	EVT_MIDDLE_UP(CCodeView::OnMouseUpM)
 	EVT_MENU(-1, CCodeView::OnPopupMenu)
 	EVT_SIZE(CCodeView::OnResize)
 END_EVENT_TABLE()
@@ -130,6 +133,15 @@ void CCodeView::OnMouseMove(wxMouseEvent& event)
 	event.Skip(true);
 }
 
+void CCodeView::OnMouseScroll(wxMouseEvent& event)
+{
+    curAddress -= event.m_wheelRotation * align / event.m_wheelDelta;
+	selection = curAddress;
+    Refresh();
+	RaiseEvent();
+    event.Skip(true);
+}
+
 void CCodeView::RaiseEvent()
 {
 	wxCommandEvent ev(wxEVT_CODEVIEW_CHANGE, GetId());
@@ -147,6 +159,25 @@ void CCodeView::OnMouseUpL(wxMouseEvent& event)
 		Refresh();
 	}
 	RaiseEvent();
+	event.Skip(true);
+}
+
+void CCodeView::OnMouseDownM(wxMouseEvent& event)
+{
+	selection = curAddress;
+	selecting = true;
+	event.Skip(true);
+}
+
+void CCodeView::OnMouseUpM(wxMouseEvent& event)
+{
+	u32 dest = AddrToBranch(selection);
+	if (dest)
+	{
+		Center(dest);
+		RaiseEvent();
+	}
+	selecting = false;
 	event.Skip(true);
 }
 

--- a/Source/Core/DolphinWX/Src/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Src/Debugger/CodeView.h
@@ -28,8 +28,11 @@ public:
 	void OnErase(wxEraseEvent& event);
 	void OnMouseDown(wxMouseEvent& event);
 	void OnMouseMove(wxMouseEvent& event);
+	void OnMouseScroll(wxMouseEvent& event);
 	void OnMouseUpL(wxMouseEvent& event);
 	void OnMouseUpR(wxMouseEvent& event);
+	void OnMouseDownM(wxMouseEvent& event);
+	void OnMouseUpM(wxMouseEvent& event);
 	void OnPopupMenu(wxCommandEvent& event);
 	void InsertBlrNop(int);
 

--- a/Source/Core/DolphinWX/Src/Debugger/MemoryView.h
+++ b/Source/Core/DolphinWX/Src/Debugger/MemoryView.h
@@ -16,12 +16,20 @@ public:
 	void OnPaint(wxPaintEvent& event);
 	void OnMouseDownL(wxMouseEvent& event);
 	void OnMouseMove(wxMouseEvent& event);
+    void OnMouseScroll(wxMouseEvent& event);
 	void OnMouseUpL(wxMouseEvent& event);
 	void OnMouseDownR(wxMouseEvent& event);
 	void OnPopupMenu(wxCommandEvent& event);
 
 	u32 GetSelection() { return selection ; }
 	int GetMemoryType() { return memory; }
+
+	void SetWordNum(int w = 0) 
+	{
+		if(w)
+			wordNum = w;
+		align = insSz * ((viewAsType == VIEWAS_HEX) ? wordNum : 1); 
+	}
 
 	void Center(u32 addr)
 	{
@@ -37,6 +45,8 @@ private:
 
 	DebugInterface* debugger;
 
+    int insSz;
+	int wordNum;
 	int align;
 	int rowHeight;
 

--- a/Source/Core/DolphinWX/Src/Debugger/MemoryWindow.h
+++ b/Source/Core/DolphinWX/Src/Debugger/MemoryWindow.h
@@ -8,6 +8,7 @@
 #include <wx/dialog.h>
 #include <wx/textctrl.h>
 #include <wx/listbox.h>
+#include <wx/spinctrl.h>
 #include "MemoryView.h"
 #include "Thread.h"
 #include "StringUtil.h"
@@ -29,12 +30,13 @@ class CMemoryWindow
 					  long style = wxTAB_TRAVERSAL | wxBORDER_NONE,
 					  const wxString& name = _("Memory"));
 
-		wxCheckBox* chk8;
-		wxCheckBox* chk16;
-		wxCheckBox* chk32;
+		wxRadioButton* rad8;
+		wxRadioButton* rad16;
+		wxRadioButton* rad32;
 		wxButton*   btnSearch;
-		wxCheckBox* chkAscii;
-		wxCheckBox* chkHex;
+		wxRadioButton* radAscii;
+		wxRadioButton* radHex;
+		wxSpinCtrl*	spnWord;
 		void Save(IniFile& _IniFile) const;
 		void Load(IniFile& _IniFile);
 
@@ -53,9 +55,8 @@ class CMemoryWindow
 		wxTextCtrl* addrbox;
 		wxTextCtrl* valbox;
 
-		void U8(wxCommandEvent& event);
-		void U16(wxCommandEvent& event);
-		void U32(wxCommandEvent& event);
+		void onDataTypeChange(wxCommandEvent& event);
+		void onWordNumChange(wxSpinEvent& event);
 		void onSearch(wxCommandEvent& event);
 		void onAscii(wxCommandEvent& event);
 		void onHex(wxCommandEvent& event);


### PR DESCRIPTION
The biggest thing I wanted to do was fix hex view and jumping when you try to click around. I also ended up adding scrolling functions to both views (I kept trying to scroll and then remembered I couldn't). I also added middle click to follow branch at current address.

In addition, I cut out some uneeded draw calls and functions, and the 'f:' specifier before every number in float view because I felt it was superfluous. 
