### PR TITLE
Implement SwapInterval for AGL interface

### DIFF
--- a/Source/Core/DolphinWX/Src/GLInterface/AGL.cpp
+++ b/Source/Core/DolphinWX/Src/GLInterface/AGL.cpp
@@ -121,4 +121,10 @@ void cInterfaceAGL::Update()
 	[GLWin.cocoaCtx update];
 }
 
+void cInterfaceAGL::SwapInterval(int Interval)
+{
+
+  [GLWin.cocoaCtx setValues:(GLint *)&Interval forParameter:NSOpenGLCPSwapInterval];
+}
+
 

--- a/Source/Core/DolphinWX/Src/GLInterface/AGL.h
+++ b/Source/Core/DolphinWX/Src/GLInterface/AGL.h
@@ -33,6 +33,7 @@ public:
 	bool ClearCurrent();
 	void Shutdown();
 	void Update();
+  void SwapInterval(int Interval);
 
 };
 #endif


### PR DESCRIPTION
Implemented the correct call to the cocoa NSOpenGLContext to set the swap interval, so the VSync video setting works in OSX.
